### PR TITLE
Dave's updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /node_modules/
+filter.yaml

--- a/Pulumi.kubecon23-demo.yaml
+++ b/Pulumi.kubecon23-demo.yaml
@@ -2,9 +2,15 @@ encryptionsalt: v1:tBCJNty1IZE=:v1:HZbUnsXfuyqSrR1N:n+95jfP3VvRVyOVo0Pc3QGRtWRPF
 config:
   demo-infra:cloudConnectToken:
     secure: v1:Tp4aVs7zZis+4+bC:WPILCInd/gkAkd/AraC/L6T6k0FCA63zivYYGqQ/QPN1z0z84XoCwx6vn6MmoA29FXZXniUri5LEV9w8oj8mTHaOZPfklbIIs3genM5njQx3JTP+ZOh1vkkurUm8/1KFOUpX2UoH9WHRyK20D3v6LnqHaIE=
+  demo-infra:edgeyHostPrefix: edgey
   demo-infra:email: dsudia@datawire.io
-  demo-infra:hostPrefix: na23
+  demo-infra:emojiHostPrefix: emoji
+  demo-infra:googleOauthClientId:
+    secure: v1:oQuZF96QbKT68mOW:C2pIkQ7rHzt0peNlGOLhIv/EAKnNWaxjAihXnnPd6ZfUzph3pgksqwvPoDge9cc9ye1aUuBAfymE6lExL2WOKMgx3hxgmqdAGwg/+j/GtYCSpLaPO9e0Pg==
+  demo-infra:googleOauthSecret:
+    secure: v1:sfXO1GL9Tblf9JAw:d4CH/C19YJbNtOdyywb71TA6otSDyGmMBZtSVWF3c1xhynWxO/hcc2kMqvjeuKaqGht0
   demo-infra:providerCluster: kubecon23-demo
   demo-infra:providerContext: kubecon23-demo
   demo-infra:providerKubeconfigPath: /Users/davesudia/.kube/config
   demo-infra:route53ZoneId: Z066394514EF7LPNGFVV
+  demo-infra:xssHostPrefix: waf

--- a/Pulumi.kubecon23-demo.yaml
+++ b/Pulumi.kubecon23-demo.yaml
@@ -1,0 +1,10 @@
+encryptionsalt: v1:tBCJNty1IZE=:v1:HZbUnsXfuyqSrR1N:n+95jfP3VvRVyOVo0Pc3QGRtWRPFhQ==
+config:
+  demo-infra:cloudConnectToken:
+    secure: v1:Tp4aVs7zZis+4+bC:WPILCInd/gkAkd/AraC/L6T6k0FCA63zivYYGqQ/QPN1z0z84XoCwx6vn6MmoA29FXZXniUri5LEV9w8oj8mTHaOZPfklbIIs3genM5njQx3JTP+ZOh1vkkurUm8/1KFOUpX2UoH9WHRyK20D3v6LnqHaIE=
+  demo-infra:email: dsudia@datawire.io
+  demo-infra:hostPrefix: na23
+  demo-infra:providerCluster: kubecon23-demo
+  demo-infra:providerContext: kubecon23-demo
+  demo-infra:providerKubeconfigPath: /Users/davesudia/.kube/config
+  demo-infra:route53ZoneId: Z066394514EF7LPNGFVV

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ After creating the new stack, set up the following config values.  Set with `pul
 
 Requires the following secret value.  Set with `pulumi config --secret <key> <value>`
 
-- `cloudConnectToken`: The un-base64 encoded cloud connect token value from Ambassador Cloud.  Go to `https://app.getambassador.io/cloud/clusters`, login and select "Add Cluster:Namespace" and create a cloud token.
+- `cloudConnectToken`: The base64 encoded cloud connect token value from Ambassador Cloud.  Go to `https://app.getambassador.io/cloud/clusters`, login and select "Add Cluster:Namespace" and create a cloud token.
 
 Finally, run `pulumi up` to pull up your new Edge Stack + TP stack!
 

--- a/ambassador/auth.ts
+++ b/ambassador/auth.ts
@@ -1,0 +1,40 @@
+import * as ambassadorCRDs from '../crds/ambassador'
+import * as ambassador from '../ambassador'
+import config from '../config'
+
+export const googleFilter = new ambassadorCRDs.getambassador.v3alpha1.Filter('google', {
+    metadata: {
+        name: 'google',
+        namespace: ambassador.ambassadorNamespace.metadata.name,
+    },
+    spec: {
+        'OAuth2': {
+            authorizationUrl: 'https://accounts.google.com',
+            protectedOrigins: [{
+                origin: 'https://edgey.kubecon.k736.net'
+            }],
+            clientID: config.requireSecret('googleOauthClientId'),
+            secret: config.requireSecret('googleOauthSecret'),
+        }
+    }
+})
+
+export const googleFilterPolicy = new ambassadorCRDs.getambassador.v3alpha1.FilterPolicy('google', {
+    metadata: {
+        name: 'google',
+        namespace: ambassador.ambassadorNamespace.metadata.name,
+    },
+    spec: {
+        rules: [
+            {
+                host: 'edgey.kubecon.k736.net',
+                path: '/',
+                filters: [
+                    {
+                        name: 'google'
+                    }
+                ]
+            }
+        ]
+    }
+})

--- a/ambassador/index.ts
+++ b/ambassador/index.ts
@@ -164,8 +164,8 @@ export const chart = new helm.v3.Chart('edge-stack',{
           'a8r.io/runbook': 'https://github.com/a8r-se/demo-infra/issues',
           'a8r.io/support': 'https://github.com/a8r-se/demo-infra/issues',
           'a8r.io/uptime': 'https://github.com/a8r-se/demo-infra/issues',
-          'kubeception.ingress.type': 'sni',
-          'kubeception.ingress.name': 'edge-stack',
+//          'kubeception.ingress.type': 'sni',
+//          'kubeception.ingress.name': 'edge-stack',
         },
       },
       adminService: {
@@ -217,7 +217,7 @@ export const chart = new helm.v3.Chart('edge-stack',{
 }, { provider: cluster.provider, dependsOn: [edgeStackCRDs, apiext, edgeStackRedisDeployment, edgeStackRedisService] })
 
 const ambassadorSvc = chart.getResource('v1/Service', 'ambassador/edge-stack')
-export const publicURL = ambassadorSvc.status.loadBalancer.ingress[0].hostname
+export const publicIp = ambassadorSvc.status.loadBalancer.ingress[0].ip
 
 // Connector config
 export const k8sEndpointResolver = new ambassadorCRDs.getambassador.v3alpha1.KubernetesEndpointResolver('endpoint', {

--- a/ambassador/index.ts
+++ b/ambassador/index.ts
@@ -125,7 +125,7 @@ export const edgeStackRedisDeployment = new k8s.apps.v1.Deployment('edge-stack-r
 
 export const chart = new helm.v3.Chart('edge-stack',{
   chart: 'edge-stack',
-  version: '8.7.0',
+  version: '8.8.2',
   namespace: ambassadorNamespace.metadata.name,
   fetchOpts: {
     repo: 'https://s3.amazonaws.com/datawire-static-files/charts',
@@ -164,6 +164,8 @@ export const chart = new helm.v3.Chart('edge-stack',{
           'a8r.io/runbook': 'https://github.com/a8r-se/demo-infra/issues',
           'a8r.io/support': 'https://github.com/a8r-se/demo-infra/issues',
           'a8r.io/uptime': 'https://github.com/a8r-se/demo-infra/issues',
+          'kubeception.ingress.type': 'sni',
+          'kubeception.ingress.name': 'edge-stack',
         },
       },
       adminService: {
@@ -215,7 +217,7 @@ export const chart = new helm.v3.Chart('edge-stack',{
 }, { provider: cluster.provider, dependsOn: [edgeStackCRDs, apiext, edgeStackRedisDeployment, edgeStackRedisService] })
 
 const ambassadorSvc = chart.getResource('v1/Service', 'ambassador/edge-stack')
-export const publicIp = ambassadorSvc.status.loadBalancer.ingress[0].ip
+export const publicURL = ambassadorSvc.status.loadBalancer.ingress[0].hostname
 
 // Connector config
 export const k8sEndpointResolver = new ambassadorCRDs.getambassador.v3alpha1.KubernetesEndpointResolver('endpoint', {

--- a/ambassador/ratelimit.ts
+++ b/ambassador/ratelimit.ts
@@ -1,0 +1,19 @@
+import * as ambassador from './index'
+import * as ambassadorCRDs from '../crds/ambassador'
+import * as cluster from "../cluster"
+
+export const voteRateLimiter = new ambassadorCRDs.getambassador.v3alpha1.RateLimit('vote-rate-limiter', {
+  metadata: {
+    name: 'vote-rate-limit',
+    namespace: ambassador.ambassadorNamespace.metadata.name,
+  },
+  spec: {
+    domain: 'ambassador',
+    limits: [{
+      pattern: [{'remote_address': '*'}],
+      rate: 3,
+      unit: 'minute'
+    }]
+  },
+}, { provider: cluster.provider, dependsOn: [ambassador.apiext] })
+

--- a/ambassador/waf.ts
+++ b/ambassador/waf.ts
@@ -1,0 +1,50 @@
+import * as ambassadorCRDs from '../crds/ambassador/gateway'
+import * as ambassador from './index'
+import * as cluster from "../cluster";
+import * as xss from '../xss'
+
+export const waf = new ambassadorCRDs.v1alpha1.WebApplicationFirewall('waf', {
+  metadata: {
+    name: 'xss-waf',
+    namespace: ambassador.ambassadorNamespace.metadata.name
+  },
+  spec: {
+    logging: {
+      onInterrupt: {
+       enabled: true, 
+      },
+    },
+    firewallRules: [{
+      sourceType: 'http',
+      http: {
+        url: 'https://app.getambassador.io/download/waf/v1-20230825/aes-waf.conf'
+      },
+    }, {
+      sourceType: 'http',
+      http: {
+        url: 'https://app.getambassador.io/download/waf/v1-20230825/crs-setup.conf'
+      }
+    }, {
+      sourceType: 'http',
+      http: {
+        url: 'https://app.getambassador.io/download/waf/v1-20230825/waf-rules.conf'
+      }
+    }]
+  },
+}, { provider: cluster.provider })
+
+export const wafPolicy = new ambassadorCRDs.v1alpha1.WebApplicationFirewallPolicy('waf-policy', {
+  metadata: {
+    name: 'xss-waf-policy',
+    namespace: ambassador.ambassadorNamespace.metadata.name
+  },
+  spec: {
+    rules: [{
+      host: xss.xssDomain.fqdn,
+      wafRef: {
+        name: 'xss-waf',
+        namespace: ambassador.ambassadorNamespace.metadata.name 
+      }
+    }]
+  }
+}, { provider: cluster.provider })

--- a/crds/ambassador/gateway/v1alpha1/index.ts
+++ b/crds/ambassador/gateway/v1alpha1/index.ts
@@ -29,4 +29,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "gateway.getambassador.io/v1alpha1", _module)
+pulumi.runtime.registerResourceModule("crds", "gateway.getambassador.io/v1alpha1", _module)

--- a/crds/ambassador/getambassador/v1/index.ts
+++ b/crds/ambassador/getambassador/v1/index.ts
@@ -99,4 +99,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "getambassador.io/v1", _module)
+pulumi.runtime.registerResourceModule("crds", "getambassador.io/v1", _module)

--- a/crds/ambassador/getambassador/v1beta1/index.ts
+++ b/crds/ambassador/getambassador/v1beta1/index.ts
@@ -22,4 +22,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "getambassador.io/v1beta1", _module)
+pulumi.runtime.registerResourceModule("crds", "getambassador.io/v1beta1", _module)

--- a/crds/ambassador/getambassador/v1beta2/index.ts
+++ b/crds/ambassador/getambassador/v1beta2/index.ts
@@ -36,4 +36,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "getambassador.io/v1beta2", _module)
+pulumi.runtime.registerResourceModule("crds", "getambassador.io/v1beta2", _module)

--- a/crds/ambassador/getambassador/v2/index.ts
+++ b/crds/ambassador/getambassador/v2/index.ts
@@ -127,4 +127,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "getambassador.io/v2", _module)
+pulumi.runtime.registerResourceModule("crds", "getambassador.io/v2", _module)

--- a/crds/ambassador/getambassador/v3alpha1/index.ts
+++ b/crds/ambassador/getambassador/v3alpha1/index.ts
@@ -134,4 +134,4 @@ const _module = {
         }
     },
 };
-pulumi.runtime.registerResourceModule("aescrds", "getambassador.io/v3alpha1", _module)
+pulumi.runtime.registerResourceModule("crds", "getambassador.io/v3alpha1", _module)

--- a/crds/ambassador/index.ts
+++ b/crds/ambassador/index.ts
@@ -21,7 +21,7 @@ export {
     getambassador,
     types,
 };
-pulumi.runtime.registerResourcePackage("aescrds", {
+pulumi.runtime.registerResourcePackage("crds", {
     version: utilities.getVersion(),
     constructProvider: (name: string, type: string, urn: string): pulumi.ProviderResource => {
         if (type !== "pulumi:providers:crds") {

--- a/crds/ambassador/package.json
+++ b/crds/ambassador/package.json
@@ -1,18 +1,19 @@
 {
-    "name": "@pulumi/aescrds",
+    "name": "@pulumi/crds",
     "version": "",
     "scripts": {
         "build": "tsc",
-        "install": "node scripts/install-pulumi-plugin.js resource aescrds "
+        "install": "node scripts/install-pulumi-plugin.js resource crds "
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
+        "@types/node": "^14",
         "typescript": "^4.3.5"
-    },
-    "peerDependencies": {
-        "@pulumi/pulumi": "latest"
     },
     "pulumi": {
         "resource": true,
-        "name": "aescrds"
+        "name": "crds"
     }
 }

--- a/crds/ambassador/provider.ts
+++ b/crds/ambassador/provider.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export class Provider extends pulumi.ProviderResource {
     /** @internal */
-    public static readonly __pulumiType = 'aescrds';
+    public static readonly __pulumiType = 'crds';
 
     /**
      * Returns true if the given object is an instance of Provider.  This is designed to work even

--- a/crds/ambassador/types/input.ts
+++ b/crds/ambassador/types/input.ts
@@ -18,7 +18,7 @@ export namespace gateway {
             /**
              * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
              */
-            ambassadorSelector?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecAmbassadorselectorArgs>;
+            ambassadorSelector?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecAmbassadorSelectorArgs>;
             /**
              * Set of matching rules that are checked against incoming request to determine which set of WebApplicationFirewalls to apply. If no matches are found then the request is allowed through to the upstream service.
              */
@@ -28,7 +28,7 @@ export namespace gateway {
         /**
          * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
          */
-        export interface WebApplicationFirewallPolicySpecAmbassadorselectorArgs {
+        export interface WebApplicationFirewallPolicySpecAmbassadorSelectorArgs {
             /**
              * limits this resource to be used only by instances of Edge Stack that have an AMBASSADOR_ID matching one of the ids in the list
              */
@@ -46,11 +46,11 @@ export namespace gateway {
             /**
              * Checks if exact or regular expression matches a value in a request Header to determine if the WebApplicationFirewall is executed or not.
              */
-            ifRequestHeader?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesIfrequestheaderArgs>;
+            ifRequestHeader?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesIfRequestHeaderArgs>;
             /**
              * Provides a way to configure how requests are handled when a request matches the rule but there is a configuration or runtime error. When this field is not configured, the default behavior is to allow the request.
              */
-            onError?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesOnerrorArgs>;
+            onError?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesOnErrorArgs>;
             /**
              * A "glob-string" that matches on the request path. If not provided then it will match on all incoming requests.
              */
@@ -62,7 +62,7 @@ export namespace gateway {
             /**
              * References a WebApplicationFirewall that will be applied to the incoming request.
              */
-            wafRef: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesWafrefArgs>;
+            wafRef: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesWafRefArgs>;
         }
         /**
          * webApplicationFirewallPolicySpecRulesArgsProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRulesArgs
@@ -71,7 +71,7 @@ export namespace gateway {
             return {
                 ...val,
                 host: (val.host) ?? "*",
-                ifRequestHeader: (val.ifRequestHeader ? pulumi.output(val.ifRequestHeader).apply(inputs.gateway.v1alpha1.webApplicationFirewallPolicySpecRulesIfrequestheaderArgsProvideDefaults) : undefined),
+                ifRequestHeader: (val.ifRequestHeader ? pulumi.output(val.ifRequestHeader).apply(inputs.gateway.v1alpha1.webApplicationFirewallPolicySpecRulesIfRequestHeaderArgsProvideDefaults) : undefined),
                 path: (val.path) ?? "*",
             };
         }
@@ -79,7 +79,7 @@ export namespace gateway {
         /**
          * Checks if exact or regular expression matches a value in a request Header to determine if the WebApplicationFirewall is executed or not.
          */
-        export interface WebApplicationFirewallPolicySpecRulesIfrequestheaderArgs {
+        export interface WebApplicationFirewallPolicySpecRulesIfRequestHeaderArgs {
             /**
              * Name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). 
              *  Valid values include: 
@@ -105,9 +105,9 @@ export namespace gateway {
             value?: pulumi.Input<string>;
         }
         /**
-         * webApplicationFirewallPolicySpecRulesIfrequestheaderArgsProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRulesIfrequestheaderArgs
+         * webApplicationFirewallPolicySpecRulesIfRequestHeaderArgsProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRulesIfRequestHeaderArgs
          */
-        export function webApplicationFirewallPolicySpecRulesIfrequestheaderArgsProvideDefaults(val: WebApplicationFirewallPolicySpecRulesIfrequestheaderArgs): WebApplicationFirewallPolicySpecRulesIfrequestheaderArgs {
+        export function webApplicationFirewallPolicySpecRulesIfRequestHeaderArgsProvideDefaults(val: WebApplicationFirewallPolicySpecRulesIfRequestHeaderArgs): WebApplicationFirewallPolicySpecRulesIfRequestHeaderArgs {
             return {
                 ...val,
                 type: (val.type) ?? "Exact",
@@ -117,7 +117,7 @@ export namespace gateway {
         /**
          * Provides a way to configure how requests are handled when a request matches the rule but there is a configuration or runtime error. When this field is not configured, the default behavior is to allow the request.
          */
-        export interface WebApplicationFirewallPolicySpecRulesOnerrorArgs {
+        export interface WebApplicationFirewallPolicySpecRulesOnErrorArgs {
             /**
              * statusCode sets the HTTP status code to use when denying the request.
              */
@@ -127,7 +127,7 @@ export namespace gateway {
         /**
          * References a WebApplicationFirewall that will be applied to the incoming request.
          */
-        export interface WebApplicationFirewallPolicySpecRulesWafrefArgs {
+        export interface WebApplicationFirewallPolicySpecRulesWafRefArgs {
             /**
              * Name of the WebApplicationFirewall
              */
@@ -153,7 +153,7 @@ export namespace gateway {
              *  * "Accepted" * "Ready" * "Rejected" - if any rules have an error then the whole WebApplicationFirewallPolicy will be rejected.
              */
             conditions?: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusConditionsArgs>[]>;
-            ruleStatuses?: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRulestatusesArgs>[]>;
+            ruleStatuses?: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRuleStatusesArgs>[]>;
         }
 
         /**
@@ -191,11 +191,11 @@ export namespace gateway {
         /**
          * Describes the status of a Rule within a WebApplicationFirewallPolicy.
          */
-        export interface WebApplicationFirewallPolicyStatusRulestatusesArgs {
+        export interface WebApplicationFirewallPolicyStatusRuleStatusesArgs {
             /**
              * conditions describe the current state of this Rule.
              */
-            conditions: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRulestatusesConditionsArgs>[]>;
+            conditions: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRuleStatusesConditionsArgs>[]>;
             /**
              * host of the rule with the error.
              */
@@ -215,7 +215,7 @@ export namespace gateway {
          *  type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: "Available", "Progressing", and "Degraded" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` 
          *  // other fields }
          */
-        export interface WebApplicationFirewallPolicyStatusRulestatusesConditionsArgs {
+        export interface WebApplicationFirewallPolicyStatusRuleStatusesConditionsArgs {
             /**
              * lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
              */
@@ -249,8 +249,8 @@ export namespace gateway {
             /**
              * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
              */
-            ambassadorSelector?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecAmbassadorselectorArgs>;
-            firewallRules: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrulesArgs>[]>;
+            ambassadorSelector?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecAmbassadorSelectorArgs>;
+            firewallRules: pulumi.Input<pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRulesArgs>[]>;
             /**
              * Provides a way to configure additional logging in the Edge Stack pods for the WebApplicationFirewall. This is in addition to the logging config that is available via the firewall configuration files. The following logs will always be output to the container logs when enabled.
              */
@@ -260,7 +260,7 @@ export namespace gateway {
         /**
          * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
          */
-        export interface WebApplicationFirewallSpecAmbassadorselectorArgs {
+        export interface WebApplicationFirewallSpecAmbassadorSelectorArgs {
             /**
              * limits this resource to be used only by instances of Edge Stack that have an AMBASSADOR_ID matching one of the ids in the list
              */
@@ -270,11 +270,11 @@ export namespace gateway {
         /**
          * Contains configuration for where to load rules for a specific WebApplicationFirewall.
          */
-        export interface WebApplicationFirewallSpecFirewallrulesArgs {
+        export interface WebApplicationFirewallSpecFirewallRulesArgs {
             /**
              * Contains a name and namespace reference to a Kubernetes ConfigMap and a key to pull data from
              */
-            configMapRef?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrulesConfigmaprefArgs>;
+            configMapRef?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRulesConfigMapRefArgs>;
             /**
              * Provides a path to a file or directory on the Edge Stack pod to load rules configuration from
              */
@@ -282,7 +282,7 @@ export namespace gateway {
             /**
              * Configures downloading firewall rules from the internet via an HTTP request
              */
-            http?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrulesHttpArgs>;
+            http?: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRulesHttpArgs>;
             /**
              * Indicates the method that we will use to load rules configuration for the WebApplicationFirewall
              */
@@ -292,7 +292,7 @@ export namespace gateway {
         /**
          * Contains a name and namespace reference to a Kubernetes ConfigMap and a key to pull data from
          */
-        export interface WebApplicationFirewallSpecFirewallrulesConfigmaprefArgs {
+        export interface WebApplicationFirewallSpecFirewallRulesConfigMapRefArgs {
             /**
              * Key for the field in the configmap that should be use
              */
@@ -316,7 +316,7 @@ export namespace gateway {
         /**
          * Configures downloading firewall rules from the internet via an HTTP request
          */
-        export interface WebApplicationFirewallSpecFirewallrulesHttpArgs {
+        export interface WebApplicationFirewallSpecFirewallRulesHttpArgs {
             /**
              * Provides the address to download the firewall rules from.
              */
@@ -330,13 +330,13 @@ export namespace gateway {
             /**
              * Controls logging behavior when the WebApplicationFirewall interrupts a request.
              */
-            onInterrupt: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecLoggingOninterruptArgs>;
+            onInterrupt: pulumi.Input<inputs.gateway.v1alpha1.WebApplicationFirewallSpecLoggingOnInterruptArgs>;
         }
 
         /**
          * Controls logging behavior when the WebApplicationFirewall interrupts a request.
          */
-        export interface WebApplicationFirewallSpecLoggingOninterruptArgs {
+        export interface WebApplicationFirewallSpecLoggingOnInterruptArgs {
             /**
              * Configures whether the container should output logs. These additional logs are not enabled unless this is set to `true`
              */
@@ -454,9 +454,9 @@ export namespace getambassador {
              * TODO(lukeshu): In v3alpha2, consider renameing `auth_service` to just `service`, for consistency with the other resource types.
              */
             auth_service: pulumi.Input<string>;
-            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecCircuit_breakersArgs>[]>;
+            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecCircuitBreakersArgs>[]>;
             failure_mode_allow?: pulumi.Input<boolean>;
-            include_body?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecInclude_bodyArgs>;
+            include_body?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecIncludeBodyArgs>;
             path_prefix?: pulumi.Input<string>;
             proto?: pulumi.Input<string>;
             /**
@@ -467,16 +467,16 @@ export namespace getambassador {
             /**
              * TODO(lukeshu): In v3alpha2, consider getting rid of this struct type in favor of just using an int (i.e. `statusOnError: 500` instead of the current `statusOnError: { code: 500 }`).
              */
-            status_on_error?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecStatus_on_errorArgs>;
+            status_on_error?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecStatusOnErrorArgs>;
             timeout_ms?: pulumi.Input<number>;
             tls?: pulumi.Input<string>;
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecV2explicittlsArgs>;
+            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.AuthServiceSpecV2ExplicitTLSArgs>;
         }
 
-        export interface AuthServiceSpecCircuit_breakersArgs {
+        export interface AuthServiceSpecCircuitBreakersArgs {
             max_connections?: pulumi.Input<number>;
             max_pending_requests?: pulumi.Input<number>;
             max_requests?: pulumi.Input<number>;
@@ -484,7 +484,7 @@ export namespace getambassador {
             priority?: pulumi.Input<string>;
         }
 
-        export interface AuthServiceSpecInclude_bodyArgs {
+        export interface AuthServiceSpecIncludeBodyArgs {
             allow_partial: pulumi.Input<boolean>;
             /**
              * These aren't pointer types because they are required.
@@ -495,14 +495,14 @@ export namespace getambassador {
         /**
          * TODO(lukeshu): In v3alpha2, consider getting rid of this struct type in favor of just using an int (i.e. `statusOnError: 500` instead of the current `statusOnError: { code: 500 }`).
          */
-        export interface AuthServiceSpecStatus_on_errorArgs {
+        export interface AuthServiceSpecStatusOnErrorArgs {
             code?: pulumi.Input<number>;
         }
 
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface AuthServiceSpecV2explicittlsArgs {
+        export interface AuthServiceSpecV2ExplicitTLSArgs {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -629,7 +629,7 @@ export namespace getambassador {
             /**
              * Specifies whether/who to talk ACME with to automatically manage the $tlsSecret.
              */
-            acmeProvider?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecAcmeproviderArgs>;
+            acmeProvider?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecAcmeProviderArgs>;
             /**
              * Common to all Ambassador objects (and optional).
              */
@@ -641,15 +641,15 @@ export namespace getambassador {
             /**
              * Selector for Mappings we'll associate with this Host. At the moment, Selector and MappingSelector are synonyms, but that will change soon.
              */
-            mappingSelector?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecMappingselectorArgs>;
+            mappingSelector?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecMappingSelectorArgs>;
             /**
              * Configuration for the Preview URL feature of Service Preview. Defaults to preview URLs not enabled.
              */
-            previewUrl?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecPreviewurlArgs>;
+            previewUrl?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecPreviewUrlArgs>;
             /**
              * Request policy definition.
              */
-            requestPolicy?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecRequestpolicyArgs>;
+            requestPolicy?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecRequestPolicyArgs>;
             /**
              * DEPRECATED: Selector by which we can find further configuration. Use MappingSelector instead. 
              *  TODO(lukeshu): In v3alpha2, figure out how to get rid of HostSpec.DeprecatedSelector.
@@ -663,17 +663,17 @@ export namespace getambassador {
              * Name of the TLSContext the Host resource is linked with. It is not valid to specify both `tlsContext` and `tls`. 
              *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
              */
-            tlsContext?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecTlscontextArgs>;
+            tlsContext?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecTlsContextArgs>;
             /**
              * Name of the Kubernetes secret into which to save generated certificates.  If ACME is enabled (see $acmeProvider), then the default is $hostname; otherwise the default is "".  If the value is "", then we do not do TLS for this Host.
              */
-            tlsSecret?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecTlssecretArgs>;
+            tlsSecret?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecTlsSecretArgs>;
         }
 
         /**
          * Specifies whether/who to talk ACME with to automatically manage the $tlsSecret.
          */
-        export interface HostSpecAcmeproviderArgs {
+        export interface HostSpecAcmeProviderArgs {
             /**
              * Specifies who to talk ACME with to get certs. Defaults to Let's Encrypt; if "none" (case-insensitive), do not try to do ACME for this Host.
              */
@@ -683,7 +683,7 @@ export namespace getambassador {
              * Specifies the Kubernetes Secret to use to store the private key of the ACME account (essentially, where to store the auto-generated password for the auto-created ACME account).  You should not normally need to set this--the default value is based on a combination of the ACME authority being registered wit and the email address associated with the account. 
              *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
              */
-            privateKeySecret?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecAcmeproviderPrivatekeysecretArgs>;
+            privateKeySecret?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecAcmeProviderPrivateKeySecretArgs>;
             /**
              * This is normally set automatically
              */
@@ -694,7 +694,7 @@ export namespace getambassador {
          * Specifies the Kubernetes Secret to use to store the private key of the ACME account (essentially, where to store the auto-generated password for the auto-created ACME account).  You should not normally need to set this--the default value is based on a combination of the ACME authority being registered wit and the email address associated with the account. 
          *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
          */
-        export interface HostSpecAcmeproviderPrivatekeysecretArgs {
+        export interface HostSpecAcmeProviderPrivateKeySecretArgs {
             /**
              * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?
              */
@@ -704,11 +704,11 @@ export namespace getambassador {
         /**
          * Selector for Mappings we'll associate with this Host. At the moment, Selector and MappingSelector are synonyms, but that will change soon.
          */
-        export interface HostSpecMappingselectorArgs {
+        export interface HostSpecMappingSelectorArgs {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.HostSpecMappingselectorMatchexpressionsArgs>[]>;
+            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.HostSpecMappingSelectorMatchExpressionsArgs>[]>;
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -718,7 +718,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface HostSpecMappingselectorMatchexpressionsArgs {
+        export interface HostSpecMappingSelectorMatchExpressionsArgs {
             /**
              * key is the label key that the selector applies to.
              */
@@ -736,7 +736,7 @@ export namespace getambassador {
         /**
          * Configuration for the Preview URL feature of Service Preview. Defaults to preview URLs not enabled.
          */
-        export interface HostSpecPreviewurlArgs {
+        export interface HostSpecPreviewUrlArgs {
             /**
              * Is the Preview URL feature enabled?
              */
@@ -750,11 +750,11 @@ export namespace getambassador {
         /**
          * Request policy definition.
          */
-        export interface HostSpecRequestpolicyArgs {
-            insecure?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecRequestpolicyInsecureArgs>;
+        export interface HostSpecRequestPolicyArgs {
+            insecure?: pulumi.Input<inputs.getambassador.v3alpha1.HostSpecRequestPolicyInsecureArgs>;
         }
 
-        export interface HostSpecRequestpolicyInsecureArgs {
+        export interface HostSpecRequestPolicyInsecureArgs {
             action?: pulumi.Input<string>;
             additionalPort?: pulumi.Input<number>;
         }
@@ -767,7 +767,7 @@ export namespace getambassador {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.HostSpecSelectorMatchexpressionsArgs>[]>;
+            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.HostSpecSelectorMatchExpressionsArgs>[]>;
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -777,7 +777,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface HostSpecSelectorMatchexpressionsArgs {
+        export interface HostSpecSelectorMatchExpressionsArgs {
             /**
              * key is the label key that the selector applies to.
              */
@@ -815,7 +815,7 @@ export namespace getambassador {
          * Name of the TLSContext the Host resource is linked with. It is not valid to specify both `tlsContext` and `tls`. 
          *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
          */
-        export interface HostSpecTlscontextArgs {
+        export interface HostSpecTlsContextArgs {
             /**
              * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?
              */
@@ -825,7 +825,7 @@ export namespace getambassador {
         /**
          * Name of the Kubernetes secret into which to save generated certificates.  If ACME is enabled (see $acmeProvider), then the default is $hostname; otherwise the default is "".  If the value is "", then we do not do TLS for this Host.
          */
-        export interface HostSpecTlssecretArgs {
+        export interface HostSpecTlsSecretArgs {
             /**
              * name is unique within a namespace to reference a secret resource.
              */
@@ -895,7 +895,7 @@ export namespace getambassador {
             /**
              * HostBinding allows restricting which Hosts will be used for this Listener.
              */
-            hostBinding: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostbindingArgs>;
+            hostBinding: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostBindingArgs>;
             /**
              * L7Depth specifies how many layer 7 load balancers are between us and the edge of the network.
              */
@@ -925,21 +925,21 @@ export namespace getambassador {
         /**
          * HostBinding allows restricting which Hosts will be used for this Listener.
          */
-        export interface ListenerSpecHostbindingArgs {
+        export interface ListenerSpecHostBindingArgs {
             /**
              * NamespaceBindingType defines we we specify which namespaces to look for Hosts in.
              */
-            namespace?: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostbindingNamespaceArgs>;
+            namespace?: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostBindingNamespaceArgs>;
             /**
              * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
              */
-            selector?: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostbindingSelectorArgs>;
+            selector?: pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostBindingSelectorArgs>;
         }
 
         /**
          * NamespaceBindingType defines we we specify which namespaces to look for Hosts in.
          */
-        export interface ListenerSpecHostbindingNamespaceArgs {
+        export interface ListenerSpecHostBindingNamespaceArgs {
             /**
              * NamespaceFromType defines how we evaluate a NamespaceBindingType.
              */
@@ -949,11 +949,11 @@ export namespace getambassador {
         /**
          * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
          */
-        export interface ListenerSpecHostbindingSelectorArgs {
+        export interface ListenerSpecHostBindingSelectorArgs {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostbindingSelectorMatchexpressionsArgs>[]>;
+            matchExpressions?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.ListenerSpecHostBindingSelectorMatchExpressionsArgs>[]>;
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -963,7 +963,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface ListenerSpecHostbindingSelectorMatchexpressionsArgs {
+        export interface ListenerSpecHostBindingSelectorMatchExpressionsArgs {
             /**
              * key is the label key that the selector applies to.
              */
@@ -989,7 +989,7 @@ export namespace getambassador {
              */
             ambassador_id?: pulumi.Input<pulumi.Input<string>[]>;
             driver?: pulumi.Input<string>;
-            driver_config?: pulumi.Input<inputs.getambassador.v3alpha1.LogServiceSpecDriver_configArgs>;
+            driver_config?: pulumi.Input<inputs.getambassador.v3alpha1.LogServiceSpecDriverConfigArgs>;
             flush_interval_byte_size?: pulumi.Input<number>;
             flush_interval_time?: pulumi.Input<number>;
             /**
@@ -1004,11 +1004,11 @@ export namespace getambassador {
             stats_name?: pulumi.Input<string>;
         }
 
-        export interface LogServiceSpecDriver_configArgs {
-            additional_log_headers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.LogServiceSpecDriver_configAdditional_log_headersArgs>[]>;
+        export interface LogServiceSpecDriverConfigArgs {
+            additional_log_headers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.LogServiceSpecDriverConfigAdditionalLogHeadersArgs>[]>;
         }
 
-        export interface LogServiceSpecDriver_configAdditional_log_headersArgs {
+        export interface LogServiceSpecDriverConfigAdditionalLogHeadersArgs {
             during_request?: pulumi.Input<boolean>;
             during_response?: pulumi.Input<boolean>;
             during_trailer?: pulumi.Input<boolean>;
@@ -1020,8 +1020,8 @@ export namespace getambassador {
          */
         export interface MappingSpecArgs {
             add_linkerd_headers?: pulumi.Input<boolean>;
-            add_request_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecAdd_request_headersArgs>}>;
-            add_response_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecAdd_response_headersArgs>}>;
+            add_request_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecAddRequestHeadersArgs>}>;
+            add_response_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecAddResponseHeadersArgs>}>;
             /**
              * A case-insensitive list of the non-HTTP protocols to allow "upgrading" to from HTTP via the "Connection: upgrade" mechanism[1].  After the upgrade, Ambassador does not interpret the traffic, and behaves similarly to how it does for TCPMappings. 
              *  [1]: https://tools.ietf.org/html/rfc7230#section-6.7 
@@ -1045,7 +1045,7 @@ export namespace getambassador {
              */
             bypass_error_response_overrides?: pulumi.Input<boolean>;
             case_sensitive?: pulumi.Input<boolean>;
-            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecCircuit_breakersArgs>[]>;
+            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecCircuitBreakersArgs>[]>;
             cluster_idle_timeout_ms?: pulumi.Input<number>;
             cluster_max_connection_lifetime_ms?: pulumi.Input<number>;
             cluster_tag?: pulumi.Input<string>;
@@ -1062,10 +1062,10 @@ export namespace getambassador {
             /**
              * Error response overrides for this Mapping. Replaces all of the `error_response_overrides` set on the Ambassador module, if any.
              */
-            error_response_overrides?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecError_response_overridesArgs>[]>;
+            error_response_overrides?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecErrorResponseOverridesArgs>[]>;
             grpc?: pulumi.Input<boolean>;
             headers?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-            health_checks?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksArgs>[]>;
+            health_checks?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksArgs>[]>;
             /**
              * Exact match for the hostname of a request if HostRegex is false; regex match for the hostname if HostRegex is true. 
              *  Host specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that doesn't have a matching Hostname. 
@@ -1093,7 +1093,7 @@ export namespace getambassador {
              * A DomainMap is the overall Mapping.spec.Labels type. It maps domains (kind of like namespaces for Mapping labels) to arrays of label groups.
              */
             labels?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsArgs>[]>}>[]>}>;
-            load_balancer?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLoad_balancerArgs>;
+            load_balancer?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLoadBalancerArgs>;
             method?: pulumi.Input<string>;
             method_regex?: pulumi.Input<boolean>;
             modules?: pulumi.Input<pulumi.Input<{[key: string]: any}>[]>;
@@ -1121,13 +1121,13 @@ export namespace getambassador {
             /**
              * Prefix regex rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
              */
-            regex_redirect?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRegex_redirectArgs>;
-            regex_rewrite?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRegex_rewriteArgs>;
+            regex_redirect?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRegexRedirectArgs>;
+            regex_rewrite?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRegexRewriteArgs>;
             remove_request_headers?: pulumi.Input<pulumi.Input<string>[]>;
             remove_response_headers?: pulumi.Input<pulumi.Input<string>[]>;
             resolver?: pulumi.Input<string>;
             respect_dns_ttl?: pulumi.Input<boolean>;
-            retry_policy?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRetry_policyArgs>;
+            retry_policy?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecRetryPolicyArgs>;
             rewrite?: pulumi.Input<string>;
             service: pulumi.Input<string>;
             shadow?: pulumi.Input<boolean>;
@@ -1147,23 +1147,23 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecV2explicittlsArgs>;
+            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecV2ExplicitTLSArgs>;
             weight?: pulumi.Input<number>;
         }
 
-        export interface MappingSpecAdd_request_headersArgs {
+        export interface MappingSpecAddRequestHeadersArgs {
             append?: pulumi.Input<boolean>;
             v2Representation?: pulumi.Input<string>;
             value?: pulumi.Input<string>;
         }
 
-        export interface MappingSpecAdd_response_headersArgs {
+        export interface MappingSpecAddResponseHeadersArgs {
             append?: pulumi.Input<boolean>;
             v2Representation?: pulumi.Input<string>;
             value?: pulumi.Input<string>;
         }
 
-        export interface MappingSpecCircuit_breakersArgs {
+        export interface MappingSpecCircuitBreakersArgs {
             max_connections?: pulumi.Input<number>;
             max_pending_requests?: pulumi.Input<number>;
             max_requests?: pulumi.Input<number>;
@@ -1195,11 +1195,11 @@ export namespace getambassador {
         /**
          * A response rewrite for an HTTP error response
          */
-        export interface MappingSpecError_response_overridesArgs {
+        export interface MappingSpecErrorResponseOverridesArgs {
             /**
              * The new response body
              */
-            body: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecError_response_overridesBodyArgs>;
+            body: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecErrorResponseOverridesBodyArgs>;
             /**
              * The status code to match on -- not a pointer because it's required.
              */
@@ -1209,7 +1209,7 @@ export namespace getambassador {
         /**
          * The new response body
          */
-        export interface MappingSpecError_response_overridesBodyArgs {
+        export interface MappingSpecErrorResponseOverridesBodyArgs {
             /**
              * The content type to set on the error response body when using text_format or text_format_source. Defaults to 'text/plain'.
              */
@@ -1225,13 +1225,13 @@ export namespace getambassador {
             /**
              * A format string sourced from a file on the Ambassador container. Useful for larger response bodies that should not be placed inline in configuration.
              */
-            text_format_source?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecError_response_overridesBodyText_format_sourceArgs>;
+            text_format_source?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecErrorResponseOverridesBodyTextFormatSourceArgs>;
         }
 
         /**
          * A format string sourced from a file on the Ambassador container. Useful for larger response bodies that should not be placed inline in configuration.
          */
-        export interface MappingSpecError_response_overridesBodyText_format_sourceArgs {
+        export interface MappingSpecErrorResponseOverridesBodyTextFormatSourceArgs {
             /**
              * The name of a file on the Ambassador pod that contains a format text string.
              */
@@ -1241,11 +1241,11 @@ export namespace getambassador {
         /**
          * HealthCheck specifies settings for performing active health checking on upstreams
          */
-        export interface MappingSpecHealth_checksArgs {
+        export interface MappingSpecHealthChecksArgs {
             /**
              * Configuration for where the healthcheck request should be made to
              */
-            health_check: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkArgs>;
+            health_check: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckArgs>;
             /**
              * Number of expected responses for the upstream to be considered healthy. Defaults to 1.
              */
@@ -1267,21 +1267,21 @@ export namespace getambassador {
         /**
          * Configuration for where the healthcheck request should be made to
          */
-        export interface MappingSpecHealth_checksHealth_checkArgs {
+        export interface MappingSpecHealthChecksHealthCheckArgs {
             /**
              * HealthCheck for gRPC upstreams. Only one of grpc_health_check or http_health_check may be specified
              */
-            grpc?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkGrpcArgs>;
+            grpc?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckGrpcArgs>;
             /**
              * HealthCheck for HTTP upstreams. Only one of http_health_check or grpc_health_check may be specified
              */
-            http?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttpArgs>;
+            http?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttpArgs>;
         }
 
         /**
          * HealthCheck for gRPC upstreams. Only one of grpc_health_check or http_health_check may be specified
          */
-        export interface MappingSpecHealth_checksHealth_checkGrpcArgs {
+        export interface MappingSpecHealthChecksHealthCheckGrpcArgs {
             /**
              * The value of the :authority header in the gRPC health check request. If left empty the upstream name will be used.
              */
@@ -1295,15 +1295,15 @@ export namespace getambassador {
         /**
          * HealthCheck for HTTP upstreams. Only one of http_health_check or grpc_health_check may be specified
          */
-        export interface MappingSpecHealth_checksHealth_checkHttpArgs {
-            add_request_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttpAdd_request_headersArgs>}>;
-            expected_statuses?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttpExpected_statusesArgs>[]>;
+        export interface MappingSpecHealthChecksHealthCheckHttpArgs {
+            add_request_headers?: pulumi.Input<{[key: string]: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttpAddRequestHeadersArgs>}>;
+            expected_statuses?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttpExpectedStatusesArgs>[]>;
             hostname?: pulumi.Input<string>;
             path: pulumi.Input<string>;
             remove_request_headers?: pulumi.Input<pulumi.Input<string>[]>;
         }
 
-        export interface MappingSpecHealth_checksHealth_checkHttpAdd_request_headersArgs {
+        export interface MappingSpecHealthChecksHealthCheckHttpAddRequestHeadersArgs {
             append?: pulumi.Input<boolean>;
             v2Representation?: pulumi.Input<string>;
             value?: pulumi.Input<string>;
@@ -1312,7 +1312,7 @@ export namespace getambassador {
         /**
          * A range of response statuses from Start to End inclusive
          */
-        export interface MappingSpecHealth_checksHealth_checkHttpExpected_statusesArgs {
+        export interface MappingSpecHealthChecksHealthCheckHttpExpectedStatusesArgs {
             /**
              * End of the statuses to include. Must be between 100 and 599 (inclusive)
              */
@@ -1337,36 +1337,36 @@ export namespace getambassador {
             /**
              * Sets the label "destination_cluster=«Envoy destination cluster name»".
              */
-            destination_cluster?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsDestination_clusterArgs>;
+            destination_cluster?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsDestinationClusterArgs>;
             /**
              * Sets the label "«key»=«value»" (where by default «key» is "generic_key").
              */
-            generic_key?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsGeneric_keyArgs>;
+            generic_key?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsGenericKeyArgs>;
             /**
              * Sets the label "remote_address=«IP address of the client»".
              */
-            remote_address?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsRemote_addressArgs>;
+            remote_address?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsRemoteAddressArgs>;
             /**
              * If the «header_name» header is set, then set the label "«key»=«Value of the «header_name» header»"; otherwise skip applying this label group.
              */
-            request_headers?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsRequest_headersArgs>;
+            request_headers?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsRequestHeadersArgs>;
             /**
              * Sets the label "source_cluster=«Envoy source cluster name»".
              */
-            source_cluster?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsSource_clusterArgs>;
+            source_cluster?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLabelsSourceClusterArgs>;
         }
 
         /**
          * Sets the label "destination_cluster=«Envoy destination cluster name»".
          */
-        export interface MappingSpecLabelsDestination_clusterArgs {
+        export interface MappingSpecLabelsDestinationClusterArgs {
             key: pulumi.Input<string>;
         }
 
         /**
          * Sets the label "«key»=«value»" (where by default «key» is "generic_key").
          */
-        export interface MappingSpecLabelsGeneric_keyArgs {
+        export interface MappingSpecLabelsGenericKeyArgs {
             /**
              * The default is "generic_key".
              */
@@ -1378,14 +1378,14 @@ export namespace getambassador {
         /**
          * Sets the label "remote_address=«IP address of the client»".
          */
-        export interface MappingSpecLabelsRemote_addressArgs {
+        export interface MappingSpecLabelsRemoteAddressArgs {
             key: pulumi.Input<string>;
         }
 
         /**
          * If the «header_name» header is set, then set the label "«key»=«Value of the «header_name» header»"; otherwise skip applying this label group.
          */
-        export interface MappingSpecLabelsRequest_headersArgs {
+        export interface MappingSpecLabelsRequestHeadersArgs {
             header_name: pulumi.Input<string>;
             key: pulumi.Input<string>;
             omit_if_not_present?: pulumi.Input<boolean>;
@@ -1394,18 +1394,18 @@ export namespace getambassador {
         /**
          * Sets the label "source_cluster=«Envoy source cluster name»".
          */
-        export interface MappingSpecLabelsSource_clusterArgs {
+        export interface MappingSpecLabelsSourceClusterArgs {
             key: pulumi.Input<string>;
         }
 
-        export interface MappingSpecLoad_balancerArgs {
-            cookie?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLoad_balancerCookieArgs>;
+        export interface MappingSpecLoadBalancerArgs {
+            cookie?: pulumi.Input<inputs.getambassador.v3alpha1.MappingSpecLoadBalancerCookieArgs>;
             header?: pulumi.Input<string>;
             policy: pulumi.Input<string>;
             source_ip?: pulumi.Input<boolean>;
         }
 
-        export interface MappingSpecLoad_balancerCookieArgs {
+        export interface MappingSpecLoadBalancerCookieArgs {
             name: pulumi.Input<string>;
             path?: pulumi.Input<string>;
             ttl?: pulumi.Input<string>;
@@ -1414,17 +1414,17 @@ export namespace getambassador {
         /**
          * Prefix regex rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
          */
-        export interface MappingSpecRegex_redirectArgs {
+        export interface MappingSpecRegexRedirectArgs {
             pattern?: pulumi.Input<string>;
             substitution?: pulumi.Input<string>;
         }
 
-        export interface MappingSpecRegex_rewriteArgs {
+        export interface MappingSpecRegexRewriteArgs {
             pattern?: pulumi.Input<string>;
             substitution?: pulumi.Input<string>;
         }
 
-        export interface MappingSpecRetry_policyArgs {
+        export interface MappingSpecRetryPolicyArgs {
             num_retries?: pulumi.Input<number>;
             per_try_timeout?: pulumi.Input<string>;
             retry_on?: pulumi.Input<string>;
@@ -1433,7 +1433,7 @@ export namespace getambassador {
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface MappingSpecV2explicittlsArgs {
+        export interface MappingSpecV2ExplicitTLSArgs {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1496,13 +1496,13 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.RateLimitServiceSpecV2explicittlsArgs>;
+            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.RateLimitServiceSpecV2ExplicitTLSArgs>;
         }
 
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface RateLimitServiceSpecV2explicittlsArgs {
+        export interface RateLimitServiceSpecV2ExplicitTLSArgs {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1527,7 +1527,7 @@ export namespace getambassador {
              *  TODO(lukeshu): In v3alpha2, consider renaming all of the `ambassador_id` (singular) fields to `ambassador_ids` (plural).
              */
             ambassador_id?: pulumi.Input<pulumi.Input<string>[]>;
-            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.TCPMappingSpecCircuit_breakersArgs>[]>;
+            circuit_breakers?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.TCPMappingSpecCircuitBreakersArgs>[]>;
             cluster_tag?: pulumi.Input<string>;
             enable_ipv4?: pulumi.Input<boolean>;
             enable_ipv6?: pulumi.Input<boolean>;
@@ -1547,11 +1547,11 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.TCPMappingSpecV2explicittlsArgs>;
+            v2ExplicitTLS?: pulumi.Input<inputs.getambassador.v3alpha1.TCPMappingSpecV2ExplicitTLSArgs>;
             weight?: pulumi.Input<number>;
         }
 
-        export interface TCPMappingSpecCircuit_breakersArgs {
+        export interface TCPMappingSpecCircuitBreakersArgs {
             max_connections?: pulumi.Input<number>;
             max_pending_requests?: pulumi.Input<number>;
             max_requests?: pulumi.Input<number>;
@@ -1562,7 +1562,7 @@ export namespace getambassador {
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface TCPMappingSpecV2explicittlsArgs {
+        export interface TCPMappingSpecV2ExplicitTLSArgs {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1615,7 +1615,7 @@ export namespace getambassador {
              */
             ambassador_id?: pulumi.Input<pulumi.Input<string>[]>;
             config?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecConfigArgs>;
-            custom_tags?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsArgs>[]>;
+            custom_tags?: pulumi.Input<pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsArgs>[]>;
             driver: pulumi.Input<string>;
             sampling?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecSamplingArgs>;
             service: pulumi.Input<string>;
@@ -1641,26 +1641,26 @@ export namespace getambassador {
         /**
          * TracingCustomTag provides a data structure for capturing envoy's `type.tracing.v3.CustomTag`
          */
-        export interface TracingServiceSpecCustom_tagsArgs {
+        export interface TracingServiceSpecCustomTagsArgs {
             /**
              * Environment explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            environment?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsEnvironmentArgs>;
+            environment?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsEnvironmentArgs>;
             /**
              * Literal explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            literal?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsLiteralArgs>;
+            literal?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsLiteralArgs>;
             /**
              * Header explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            request_header?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsRequest_headerArgs>;
+            request_header?: pulumi.Input<inputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsRequestHeaderArgs>;
             tag: pulumi.Input<string>;
         }
 
         /**
          * Environment explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsEnvironmentArgs {
+        export interface TracingServiceSpecCustomTagsEnvironmentArgs {
             default_value?: pulumi.Input<string>;
             name: pulumi.Input<string>;
         }
@@ -1668,14 +1668,14 @@ export namespace getambassador {
         /**
          * Literal explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsLiteralArgs {
+        export interface TracingServiceSpecCustomTagsLiteralArgs {
             value: pulumi.Input<string>;
         }
 
         /**
          * Header explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsRequest_headerArgs {
+        export interface TracingServiceSpecCustomTagsRequestHeaderArgs {
             default_value?: pulumi.Input<string>;
             name: pulumi.Input<string>;
         }

--- a/crds/ambassador/types/output.ts
+++ b/crds/ambassador/types/output.ts
@@ -18,7 +18,7 @@ export namespace gateway {
             /**
              * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
              */
-            ambassadorSelector?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecAmbassadorselector;
+            ambassadorSelector?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecAmbassadorSelector;
             /**
              * Set of matching rules that are checked against incoming request to determine which set of WebApplicationFirewalls to apply. If no matches are found then the request is allowed through to the upstream service.
              */
@@ -28,7 +28,7 @@ export namespace gateway {
         /**
          * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
          */
-        export interface WebApplicationFirewallPolicySpecAmbassadorselector {
+        export interface WebApplicationFirewallPolicySpecAmbassadorSelector {
             /**
              * limits this resource to be used only by instances of Edge Stack that have an AMBASSADOR_ID matching one of the ids in the list
              */
@@ -46,11 +46,11 @@ export namespace gateway {
             /**
              * Checks if exact or regular expression matches a value in a request Header to determine if the WebApplicationFirewall is executed or not.
              */
-            ifRequestHeader?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesIfrequestheader;
+            ifRequestHeader?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesIfRequestHeader;
             /**
              * Provides a way to configure how requests are handled when a request matches the rule but there is a configuration or runtime error. When this field is not configured, the default behavior is to allow the request.
              */
-            onError?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesOnerror;
+            onError?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesOnError;
             /**
              * A "glob-string" that matches on the request path. If not provided then it will match on all incoming requests.
              */
@@ -62,7 +62,7 @@ export namespace gateway {
             /**
              * References a WebApplicationFirewall that will be applied to the incoming request.
              */
-            wafRef: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesWafref;
+            wafRef: outputs.gateway.v1alpha1.WebApplicationFirewallPolicySpecRulesWafRef;
         }
         /**
          * webApplicationFirewallPolicySpecRulesProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRules
@@ -71,7 +71,7 @@ export namespace gateway {
             return {
                 ...val,
                 host: (val.host) ?? "*",
-                ifRequestHeader: (val.ifRequestHeader ? outputs.gateway.v1alpha1.webApplicationFirewallPolicySpecRulesIfrequestheaderProvideDefaults(val.ifRequestHeader) : undefined),
+                ifRequestHeader: (val.ifRequestHeader ? outputs.gateway.v1alpha1.webApplicationFirewallPolicySpecRulesIfRequestHeaderProvideDefaults(val.ifRequestHeader) : undefined),
                 path: (val.path) ?? "*",
             };
         }
@@ -79,7 +79,7 @@ export namespace gateway {
         /**
          * Checks if exact or regular expression matches a value in a request Header to determine if the WebApplicationFirewall is executed or not.
          */
-        export interface WebApplicationFirewallPolicySpecRulesIfrequestheader {
+        export interface WebApplicationFirewallPolicySpecRulesIfRequestHeader {
             /**
              * Name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). 
              *  Valid values include: 
@@ -105,9 +105,9 @@ export namespace gateway {
             value?: string;
         }
         /**
-         * webApplicationFirewallPolicySpecRulesIfrequestheaderProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRulesIfrequestheader
+         * webApplicationFirewallPolicySpecRulesIfRequestHeaderProvideDefaults sets the appropriate defaults for WebApplicationFirewallPolicySpecRulesIfRequestHeader
          */
-        export function webApplicationFirewallPolicySpecRulesIfrequestheaderProvideDefaults(val: WebApplicationFirewallPolicySpecRulesIfrequestheader): WebApplicationFirewallPolicySpecRulesIfrequestheader {
+        export function webApplicationFirewallPolicySpecRulesIfRequestHeaderProvideDefaults(val: WebApplicationFirewallPolicySpecRulesIfRequestHeader): WebApplicationFirewallPolicySpecRulesIfRequestHeader {
             return {
                 ...val,
                 type: (val.type) ?? "Exact",
@@ -117,7 +117,7 @@ export namespace gateway {
         /**
          * Provides a way to configure how requests are handled when a request matches the rule but there is a configuration or runtime error. When this field is not configured, the default behavior is to allow the request.
          */
-        export interface WebApplicationFirewallPolicySpecRulesOnerror {
+        export interface WebApplicationFirewallPolicySpecRulesOnError {
             /**
              * statusCode sets the HTTP status code to use when denying the request.
              */
@@ -127,7 +127,7 @@ export namespace gateway {
         /**
          * References a WebApplicationFirewall that will be applied to the incoming request.
          */
-        export interface WebApplicationFirewallPolicySpecRulesWafref {
+        export interface WebApplicationFirewallPolicySpecRulesWafRef {
             /**
              * Name of the WebApplicationFirewall
              */
@@ -153,7 +153,7 @@ export namespace gateway {
              *  * "Accepted" * "Ready" * "Rejected" - if any rules have an error then the whole WebApplicationFirewallPolicy will be rejected.
              */
             conditions?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusConditions[];
-            ruleStatuses?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRulestatuses[];
+            ruleStatuses?: outputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRuleStatuses[];
         }
 
         /**
@@ -191,11 +191,11 @@ export namespace gateway {
         /**
          * Describes the status of a Rule within a WebApplicationFirewallPolicy.
          */
-        export interface WebApplicationFirewallPolicyStatusRulestatuses {
+        export interface WebApplicationFirewallPolicyStatusRuleStatuses {
             /**
              * conditions describe the current state of this Rule.
              */
-            conditions: outputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRulestatusesConditions[];
+            conditions: outputs.gateway.v1alpha1.WebApplicationFirewallPolicyStatusRuleStatusesConditions[];
             /**
              * host of the rule with the error.
              */
@@ -215,7 +215,7 @@ export namespace gateway {
          *  type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: "Available", "Progressing", and "Degraded" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` 
          *  // other fields }
          */
-        export interface WebApplicationFirewallPolicyStatusRulestatusesConditions {
+        export interface WebApplicationFirewallPolicyStatusRuleStatusesConditions {
             /**
              * lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
              */
@@ -249,8 +249,8 @@ export namespace gateway {
             /**
              * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
              */
-            ambassadorSelector?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecAmbassadorselector;
-            firewallRules: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrules[];
+            ambassadorSelector?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecAmbassadorSelector;
+            firewallRules: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRules[];
             /**
              * Provides a way to configure additional logging in the Edge Stack pods for the WebApplicationFirewall. This is in addition to the logging config that is available via the firewall configuration files. The following logs will always be output to the container logs when enabled.
              */
@@ -260,7 +260,7 @@ export namespace gateway {
         /**
          * Optional field that can be used to limit which instances of Edge Stack can make use of this resource
          */
-        export interface WebApplicationFirewallSpecAmbassadorselector {
+        export interface WebApplicationFirewallSpecAmbassadorSelector {
             /**
              * limits this resource to be used only by instances of Edge Stack that have an AMBASSADOR_ID matching one of the ids in the list
              */
@@ -270,11 +270,11 @@ export namespace gateway {
         /**
          * Contains configuration for where to load rules for a specific WebApplicationFirewall.
          */
-        export interface WebApplicationFirewallSpecFirewallrules {
+        export interface WebApplicationFirewallSpecFirewallRules {
             /**
              * Contains a name and namespace reference to a Kubernetes ConfigMap and a key to pull data from
              */
-            configMapRef?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrulesConfigmapref;
+            configMapRef?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRulesConfigMapRef;
             /**
              * Provides a path to a file or directory on the Edge Stack pod to load rules configuration from
              */
@@ -282,7 +282,7 @@ export namespace gateway {
             /**
              * Configures downloading firewall rules from the internet via an HTTP request
              */
-            http?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallrulesHttp;
+            http?: outputs.gateway.v1alpha1.WebApplicationFirewallSpecFirewallRulesHttp;
             /**
              * Indicates the method that we will use to load rules configuration for the WebApplicationFirewall
              */
@@ -292,7 +292,7 @@ export namespace gateway {
         /**
          * Contains a name and namespace reference to a Kubernetes ConfigMap and a key to pull data from
          */
-        export interface WebApplicationFirewallSpecFirewallrulesConfigmapref {
+        export interface WebApplicationFirewallSpecFirewallRulesConfigMapRef {
             /**
              * Key for the field in the configmap that should be use
              */
@@ -316,7 +316,7 @@ export namespace gateway {
         /**
          * Configures downloading firewall rules from the internet via an HTTP request
          */
-        export interface WebApplicationFirewallSpecFirewallrulesHttp {
+        export interface WebApplicationFirewallSpecFirewallRulesHttp {
             /**
              * Provides the address to download the firewall rules from.
              */
@@ -330,13 +330,13 @@ export namespace gateway {
             /**
              * Controls logging behavior when the WebApplicationFirewall interrupts a request.
              */
-            onInterrupt: outputs.gateway.v1alpha1.WebApplicationFirewallSpecLoggingOninterrupt;
+            onInterrupt: outputs.gateway.v1alpha1.WebApplicationFirewallSpecLoggingOnInterrupt;
         }
 
         /**
          * Controls logging behavior when the WebApplicationFirewall interrupts a request.
          */
-        export interface WebApplicationFirewallSpecLoggingOninterrupt {
+        export interface WebApplicationFirewallSpecLoggingOnInterrupt {
             /**
              * Configures whether the container should output logs. These additional logs are not enabled unless this is set to `true`
              */
@@ -455,9 +455,9 @@ export namespace getambassador {
              * TODO(lukeshu): In v3alpha2, consider renameing `auth_service` to just `service`, for consistency with the other resource types.
              */
             auth_service: string;
-            circuit_breakers?: outputs.getambassador.v3alpha1.AuthServiceSpecCircuit_breakers[];
+            circuit_breakers?: outputs.getambassador.v3alpha1.AuthServiceSpecCircuitBreakers[];
             failure_mode_allow?: boolean;
-            include_body?: outputs.getambassador.v3alpha1.AuthServiceSpecInclude_body;
+            include_body?: outputs.getambassador.v3alpha1.AuthServiceSpecIncludeBody;
             path_prefix?: string;
             proto?: string;
             /**
@@ -468,16 +468,16 @@ export namespace getambassador {
             /**
              * TODO(lukeshu): In v3alpha2, consider getting rid of this struct type in favor of just using an int (i.e. `statusOnError: 500` instead of the current `statusOnError: { code: 500 }`).
              */
-            status_on_error?: outputs.getambassador.v3alpha1.AuthServiceSpecStatus_on_error;
+            status_on_error?: outputs.getambassador.v3alpha1.AuthServiceSpecStatusOnError;
             timeout_ms?: number;
             tls?: string;
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: outputs.getambassador.v3alpha1.AuthServiceSpecV2explicittls;
+            v2ExplicitTLS?: outputs.getambassador.v3alpha1.AuthServiceSpecV2ExplicitTLS;
         }
 
-        export interface AuthServiceSpecCircuit_breakers {
+        export interface AuthServiceSpecCircuitBreakers {
             max_connections?: number;
             max_pending_requests?: number;
             max_requests?: number;
@@ -485,7 +485,7 @@ export namespace getambassador {
             priority?: string;
         }
 
-        export interface AuthServiceSpecInclude_body {
+        export interface AuthServiceSpecIncludeBody {
             allow_partial: boolean;
             /**
              * These aren't pointer types because they are required.
@@ -496,14 +496,14 @@ export namespace getambassador {
         /**
          * TODO(lukeshu): In v3alpha2, consider getting rid of this struct type in favor of just using an int (i.e. `statusOnError: 500` instead of the current `statusOnError: { code: 500 }`).
          */
-        export interface AuthServiceSpecStatus_on_error {
+        export interface AuthServiceSpecStatusOnError {
             code?: number;
         }
 
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface AuthServiceSpecV2explicittls {
+        export interface AuthServiceSpecV2ExplicitTLS {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -630,7 +630,7 @@ export namespace getambassador {
             /**
              * Specifies whether/who to talk ACME with to automatically manage the $tlsSecret.
              */
-            acmeProvider?: outputs.getambassador.v3alpha1.HostSpecAcmeprovider;
+            acmeProvider?: outputs.getambassador.v3alpha1.HostSpecAcmeProvider;
             /**
              * Common to all Ambassador objects (and optional).
              */
@@ -642,15 +642,15 @@ export namespace getambassador {
             /**
              * Selector for Mappings we'll associate with this Host. At the moment, Selector and MappingSelector are synonyms, but that will change soon.
              */
-            mappingSelector?: outputs.getambassador.v3alpha1.HostSpecMappingselector;
+            mappingSelector?: outputs.getambassador.v3alpha1.HostSpecMappingSelector;
             /**
              * Configuration for the Preview URL feature of Service Preview. Defaults to preview URLs not enabled.
              */
-            previewUrl?: outputs.getambassador.v3alpha1.HostSpecPreviewurl;
+            previewUrl?: outputs.getambassador.v3alpha1.HostSpecPreviewUrl;
             /**
              * Request policy definition.
              */
-            requestPolicy?: outputs.getambassador.v3alpha1.HostSpecRequestpolicy;
+            requestPolicy?: outputs.getambassador.v3alpha1.HostSpecRequestPolicy;
             /**
              * DEPRECATED: Selector by which we can find further configuration. Use MappingSelector instead. 
              *  TODO(lukeshu): In v3alpha2, figure out how to get rid of HostSpec.DeprecatedSelector.
@@ -664,17 +664,17 @@ export namespace getambassador {
              * Name of the TLSContext the Host resource is linked with. It is not valid to specify both `tlsContext` and `tls`. 
              *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
              */
-            tlsContext?: outputs.getambassador.v3alpha1.HostSpecTlscontext;
+            tlsContext?: outputs.getambassador.v3alpha1.HostSpecTlsContext;
             /**
              * Name of the Kubernetes secret into which to save generated certificates.  If ACME is enabled (see $acmeProvider), then the default is $hostname; otherwise the default is "".  If the value is "", then we do not do TLS for this Host.
              */
-            tlsSecret?: outputs.getambassador.v3alpha1.HostSpecTlssecret;
+            tlsSecret?: outputs.getambassador.v3alpha1.HostSpecTlsSecret;
         }
 
         /**
          * Specifies whether/who to talk ACME with to automatically manage the $tlsSecret.
          */
-        export interface HostSpecAcmeprovider {
+        export interface HostSpecAcmeProvider {
             /**
              * Specifies who to talk ACME with to get certs. Defaults to Let's Encrypt; if "none" (case-insensitive), do not try to do ACME for this Host.
              */
@@ -684,7 +684,7 @@ export namespace getambassador {
              * Specifies the Kubernetes Secret to use to store the private key of the ACME account (essentially, where to store the auto-generated password for the auto-created ACME account).  You should not normally need to set this--the default value is based on a combination of the ACME authority being registered wit and the email address associated with the account. 
              *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
              */
-            privateKeySecret?: outputs.getambassador.v3alpha1.HostSpecAcmeproviderPrivatekeysecret;
+            privateKeySecret?: outputs.getambassador.v3alpha1.HostSpecAcmeProviderPrivateKeySecret;
             /**
              * This is normally set automatically
              */
@@ -695,7 +695,7 @@ export namespace getambassador {
          * Specifies the Kubernetes Secret to use to store the private key of the ACME account (essentially, where to store the auto-generated password for the auto-created ACME account).  You should not normally need to set this--the default value is based on a combination of the ACME authority being registered wit and the email address associated with the account. 
          *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
          */
-        export interface HostSpecAcmeproviderPrivatekeysecret {
+        export interface HostSpecAcmeProviderPrivateKeySecret {
             /**
              * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?
              */
@@ -705,11 +705,11 @@ export namespace getambassador {
         /**
          * Selector for Mappings we'll associate with this Host. At the moment, Selector and MappingSelector are synonyms, but that will change soon.
          */
-        export interface HostSpecMappingselector {
+        export interface HostSpecMappingSelector {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: outputs.getambassador.v3alpha1.HostSpecMappingselectorMatchexpressions[];
+            matchExpressions?: outputs.getambassador.v3alpha1.HostSpecMappingSelectorMatchExpressions[];
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -719,7 +719,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface HostSpecMappingselectorMatchexpressions {
+        export interface HostSpecMappingSelectorMatchExpressions {
             /**
              * key is the label key that the selector applies to.
              */
@@ -737,7 +737,7 @@ export namespace getambassador {
         /**
          * Configuration for the Preview URL feature of Service Preview. Defaults to preview URLs not enabled.
          */
-        export interface HostSpecPreviewurl {
+        export interface HostSpecPreviewUrl {
             /**
              * Is the Preview URL feature enabled?
              */
@@ -751,11 +751,11 @@ export namespace getambassador {
         /**
          * Request policy definition.
          */
-        export interface HostSpecRequestpolicy {
-            insecure?: outputs.getambassador.v3alpha1.HostSpecRequestpolicyInsecure;
+        export interface HostSpecRequestPolicy {
+            insecure?: outputs.getambassador.v3alpha1.HostSpecRequestPolicyInsecure;
         }
 
-        export interface HostSpecRequestpolicyInsecure {
+        export interface HostSpecRequestPolicyInsecure {
             action?: string;
             additionalPort?: number;
         }
@@ -768,7 +768,7 @@ export namespace getambassador {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: outputs.getambassador.v3alpha1.HostSpecSelectorMatchexpressions[];
+            matchExpressions?: outputs.getambassador.v3alpha1.HostSpecSelectorMatchExpressions[];
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -778,7 +778,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface HostSpecSelectorMatchexpressions {
+        export interface HostSpecSelectorMatchExpressions {
             /**
              * key is the label key that the selector applies to.
              */
@@ -816,7 +816,7 @@ export namespace getambassador {
          * Name of the TLSContext the Host resource is linked with. It is not valid to specify both `tlsContext` and `tls`. 
          *  Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
          */
-        export interface HostSpecTlscontext {
+        export interface HostSpecTlsContext {
             /**
              * Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?
              */
@@ -826,7 +826,7 @@ export namespace getambassador {
         /**
          * Name of the Kubernetes secret into which to save generated certificates.  If ACME is enabled (see $acmeProvider), then the default is $hostname; otherwise the default is "".  If the value is "", then we do not do TLS for this Host.
          */
-        export interface HostSpecTlssecret {
+        export interface HostSpecTlsSecret {
             /**
              * name is unique within a namespace to reference a secret resource.
              */
@@ -896,7 +896,7 @@ export namespace getambassador {
             /**
              * HostBinding allows restricting which Hosts will be used for this Listener.
              */
-            hostBinding: outputs.getambassador.v3alpha1.ListenerSpecHostbinding;
+            hostBinding: outputs.getambassador.v3alpha1.ListenerSpecHostBinding;
             /**
              * L7Depth specifies how many layer 7 load balancers are between us and the edge of the network.
              */
@@ -926,21 +926,21 @@ export namespace getambassador {
         /**
          * HostBinding allows restricting which Hosts will be used for this Listener.
          */
-        export interface ListenerSpecHostbinding {
+        export interface ListenerSpecHostBinding {
             /**
              * NamespaceBindingType defines we we specify which namespaces to look for Hosts in.
              */
-            namespace?: outputs.getambassador.v3alpha1.ListenerSpecHostbindingNamespace;
+            namespace?: outputs.getambassador.v3alpha1.ListenerSpecHostBindingNamespace;
             /**
              * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
              */
-            selector?: outputs.getambassador.v3alpha1.ListenerSpecHostbindingSelector;
+            selector?: outputs.getambassador.v3alpha1.ListenerSpecHostBindingSelector;
         }
 
         /**
          * NamespaceBindingType defines we we specify which namespaces to look for Hosts in.
          */
-        export interface ListenerSpecHostbindingNamespace {
+        export interface ListenerSpecHostBindingNamespace {
             /**
              * NamespaceFromType defines how we evaluate a NamespaceBindingType.
              */
@@ -950,11 +950,11 @@ export namespace getambassador {
         /**
          * A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
          */
-        export interface ListenerSpecHostbindingSelector {
+        export interface ListenerSpecHostBindingSelector {
             /**
              * matchExpressions is a list of label selector requirements. The requirements are ANDed.
              */
-            matchExpressions?: outputs.getambassador.v3alpha1.ListenerSpecHostbindingSelectorMatchexpressions[];
+            matchExpressions?: outputs.getambassador.v3alpha1.ListenerSpecHostBindingSelectorMatchExpressions[];
             /**
              * matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
              */
@@ -964,7 +964,7 @@ export namespace getambassador {
         /**
          * A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
          */
-        export interface ListenerSpecHostbindingSelectorMatchexpressions {
+        export interface ListenerSpecHostBindingSelectorMatchExpressions {
             /**
              * key is the label key that the selector applies to.
              */
@@ -990,7 +990,7 @@ export namespace getambassador {
              */
             ambassador_id?: string[];
             driver?: string;
-            driver_config?: outputs.getambassador.v3alpha1.LogServiceSpecDriver_config;
+            driver_config?: outputs.getambassador.v3alpha1.LogServiceSpecDriverConfig;
             flush_interval_byte_size?: number;
             flush_interval_time?: number;
             /**
@@ -1005,11 +1005,11 @@ export namespace getambassador {
             stats_name?: string;
         }
 
-        export interface LogServiceSpecDriver_config {
-            additional_log_headers?: outputs.getambassador.v3alpha1.LogServiceSpecDriver_configAdditional_log_headers[];
+        export interface LogServiceSpecDriverConfig {
+            additional_log_headers?: outputs.getambassador.v3alpha1.LogServiceSpecDriverConfigAdditionalLogHeaders[];
         }
 
-        export interface LogServiceSpecDriver_configAdditional_log_headers {
+        export interface LogServiceSpecDriverConfigAdditionalLogHeaders {
             during_request?: boolean;
             during_response?: boolean;
             during_trailer?: boolean;
@@ -1021,8 +1021,8 @@ export namespace getambassador {
          */
         export interface MappingSpec {
             add_linkerd_headers?: boolean;
-            add_request_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecAdd_request_headers};
-            add_response_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecAdd_response_headers};
+            add_request_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecAddRequestHeaders};
+            add_response_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecAddResponseHeaders};
             /**
              * A case-insensitive list of the non-HTTP protocols to allow "upgrading" to from HTTP via the "Connection: upgrade" mechanism[1].  After the upgrade, Ambassador does not interpret the traffic, and behaves similarly to how it does for TCPMappings. 
              *  [1]: https://tools.ietf.org/html/rfc7230#section-6.7 
@@ -1046,7 +1046,7 @@ export namespace getambassador {
              */
             bypass_error_response_overrides?: boolean;
             case_sensitive?: boolean;
-            circuit_breakers?: outputs.getambassador.v3alpha1.MappingSpecCircuit_breakers[];
+            circuit_breakers?: outputs.getambassador.v3alpha1.MappingSpecCircuitBreakers[];
             cluster_idle_timeout_ms?: number;
             cluster_max_connection_lifetime_ms?: number;
             cluster_tag?: string;
@@ -1063,10 +1063,10 @@ export namespace getambassador {
             /**
              * Error response overrides for this Mapping. Replaces all of the `error_response_overrides` set on the Ambassador module, if any.
              */
-            error_response_overrides?: outputs.getambassador.v3alpha1.MappingSpecError_response_overrides[];
+            error_response_overrides?: outputs.getambassador.v3alpha1.MappingSpecErrorResponseOverrides[];
             grpc?: boolean;
             headers?: {[key: string]: string};
-            health_checks?: outputs.getambassador.v3alpha1.MappingSpecHealth_checks[];
+            health_checks?: outputs.getambassador.v3alpha1.MappingSpecHealthChecks[];
             /**
              * Exact match for the hostname of a request if HostRegex is false; regex match for the hostname if HostRegex is true. 
              *  Host specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that doesn't have a matching Hostname. 
@@ -1094,7 +1094,7 @@ export namespace getambassador {
              * A DomainMap is the overall Mapping.spec.Labels type. It maps domains (kind of like namespaces for Mapping labels) to arrays of label groups.
              */
             labels?: {[key: string]: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecLabels[]}[]};
-            load_balancer?: outputs.getambassador.v3alpha1.MappingSpecLoad_balancer;
+            load_balancer?: outputs.getambassador.v3alpha1.MappingSpecLoadBalancer;
             method?: string;
             method_regex?: boolean;
             modules?: {[key: string]: any}[];
@@ -1122,13 +1122,13 @@ export namespace getambassador {
             /**
              * Prefix regex rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
              */
-            regex_redirect?: outputs.getambassador.v3alpha1.MappingSpecRegex_redirect;
-            regex_rewrite?: outputs.getambassador.v3alpha1.MappingSpecRegex_rewrite;
+            regex_redirect?: outputs.getambassador.v3alpha1.MappingSpecRegexRedirect;
+            regex_rewrite?: outputs.getambassador.v3alpha1.MappingSpecRegexRewrite;
             remove_request_headers?: string[];
             remove_response_headers?: string[];
             resolver?: string;
             respect_dns_ttl?: boolean;
-            retry_policy?: outputs.getambassador.v3alpha1.MappingSpecRetry_policy;
+            retry_policy?: outputs.getambassador.v3alpha1.MappingSpecRetryPolicy;
             rewrite?: string;
             service: string;
             shadow?: boolean;
@@ -1148,23 +1148,23 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: outputs.getambassador.v3alpha1.MappingSpecV2explicittls;
+            v2ExplicitTLS?: outputs.getambassador.v3alpha1.MappingSpecV2ExplicitTLS;
             weight?: number;
         }
 
-        export interface MappingSpecAdd_request_headers {
+        export interface MappingSpecAddRequestHeaders {
             append?: boolean;
             v2Representation?: string;
             value?: string;
         }
 
-        export interface MappingSpecAdd_response_headers {
+        export interface MappingSpecAddResponseHeaders {
             append?: boolean;
             v2Representation?: string;
             value?: string;
         }
 
-        export interface MappingSpecCircuit_breakers {
+        export interface MappingSpecCircuitBreakers {
             max_connections?: number;
             max_pending_requests?: number;
             max_requests?: number;
@@ -1196,11 +1196,11 @@ export namespace getambassador {
         /**
          * A response rewrite for an HTTP error response
          */
-        export interface MappingSpecError_response_overrides {
+        export interface MappingSpecErrorResponseOverrides {
             /**
              * The new response body
              */
-            body: outputs.getambassador.v3alpha1.MappingSpecError_response_overridesBody;
+            body: outputs.getambassador.v3alpha1.MappingSpecErrorResponseOverridesBody;
             /**
              * The status code to match on -- not a pointer because it's required.
              */
@@ -1210,7 +1210,7 @@ export namespace getambassador {
         /**
          * The new response body
          */
-        export interface MappingSpecError_response_overridesBody {
+        export interface MappingSpecErrorResponseOverridesBody {
             /**
              * The content type to set on the error response body when using text_format or text_format_source. Defaults to 'text/plain'.
              */
@@ -1226,13 +1226,13 @@ export namespace getambassador {
             /**
              * A format string sourced from a file on the Ambassador container. Useful for larger response bodies that should not be placed inline in configuration.
              */
-            text_format_source?: outputs.getambassador.v3alpha1.MappingSpecError_response_overridesBodyText_format_source;
+            text_format_source?: outputs.getambassador.v3alpha1.MappingSpecErrorResponseOverridesBodyTextFormatSource;
         }
 
         /**
          * A format string sourced from a file on the Ambassador container. Useful for larger response bodies that should not be placed inline in configuration.
          */
-        export interface MappingSpecError_response_overridesBodyText_format_source {
+        export interface MappingSpecErrorResponseOverridesBodyTextFormatSource {
             /**
              * The name of a file on the Ambassador pod that contains a format text string.
              */
@@ -1242,11 +1242,11 @@ export namespace getambassador {
         /**
          * HealthCheck specifies settings for performing active health checking on upstreams
          */
-        export interface MappingSpecHealth_checks {
+        export interface MappingSpecHealthChecks {
             /**
              * Configuration for where the healthcheck request should be made to
              */
-            health_check: outputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_check;
+            health_check: outputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheck;
             /**
              * Number of expected responses for the upstream to be considered healthy. Defaults to 1.
              */
@@ -1268,21 +1268,21 @@ export namespace getambassador {
         /**
          * Configuration for where the healthcheck request should be made to
          */
-        export interface MappingSpecHealth_checksHealth_check {
+        export interface MappingSpecHealthChecksHealthCheck {
             /**
              * HealthCheck for gRPC upstreams. Only one of grpc_health_check or http_health_check may be specified
              */
-            grpc?: outputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkGrpc;
+            grpc?: outputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckGrpc;
             /**
              * HealthCheck for HTTP upstreams. Only one of http_health_check or grpc_health_check may be specified
              */
-            http?: outputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttp;
+            http?: outputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttp;
         }
 
         /**
          * HealthCheck for gRPC upstreams. Only one of grpc_health_check or http_health_check may be specified
          */
-        export interface MappingSpecHealth_checksHealth_checkGrpc {
+        export interface MappingSpecHealthChecksHealthCheckGrpc {
             /**
              * The value of the :authority header in the gRPC health check request. If left empty the upstream name will be used.
              */
@@ -1296,15 +1296,15 @@ export namespace getambassador {
         /**
          * HealthCheck for HTTP upstreams. Only one of http_health_check or grpc_health_check may be specified
          */
-        export interface MappingSpecHealth_checksHealth_checkHttp {
-            add_request_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttpAdd_request_headers};
-            expected_statuses?: outputs.getambassador.v3alpha1.MappingSpecHealth_checksHealth_checkHttpExpected_statuses[];
+        export interface MappingSpecHealthChecksHealthCheckHttp {
+            add_request_headers?: {[key: string]: outputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttpAddRequestHeaders};
+            expected_statuses?: outputs.getambassador.v3alpha1.MappingSpecHealthChecksHealthCheckHttpExpectedStatuses[];
             hostname?: string;
             path: string;
             remove_request_headers?: string[];
         }
 
-        export interface MappingSpecHealth_checksHealth_checkHttpAdd_request_headers {
+        export interface MappingSpecHealthChecksHealthCheckHttpAddRequestHeaders {
             append?: boolean;
             v2Representation?: string;
             value?: string;
@@ -1313,7 +1313,7 @@ export namespace getambassador {
         /**
          * A range of response statuses from Start to End inclusive
          */
-        export interface MappingSpecHealth_checksHealth_checkHttpExpected_statuses {
+        export interface MappingSpecHealthChecksHealthCheckHttpExpectedStatuses {
             /**
              * End of the statuses to include. Must be between 100 and 599 (inclusive)
              */
@@ -1338,36 +1338,36 @@ export namespace getambassador {
             /**
              * Sets the label "destination_cluster=«Envoy destination cluster name»".
              */
-            destination_cluster?: outputs.getambassador.v3alpha1.MappingSpecLabelsDestination_cluster;
+            destination_cluster?: outputs.getambassador.v3alpha1.MappingSpecLabelsDestinationCluster;
             /**
              * Sets the label "«key»=«value»" (where by default «key» is "generic_key").
              */
-            generic_key?: outputs.getambassador.v3alpha1.MappingSpecLabelsGeneric_key;
+            generic_key?: outputs.getambassador.v3alpha1.MappingSpecLabelsGenericKey;
             /**
              * Sets the label "remote_address=«IP address of the client»".
              */
-            remote_address?: outputs.getambassador.v3alpha1.MappingSpecLabelsRemote_address;
+            remote_address?: outputs.getambassador.v3alpha1.MappingSpecLabelsRemoteAddress;
             /**
              * If the «header_name» header is set, then set the label "«key»=«Value of the «header_name» header»"; otherwise skip applying this label group.
              */
-            request_headers?: outputs.getambassador.v3alpha1.MappingSpecLabelsRequest_headers;
+            request_headers?: outputs.getambassador.v3alpha1.MappingSpecLabelsRequestHeaders;
             /**
              * Sets the label "source_cluster=«Envoy source cluster name»".
              */
-            source_cluster?: outputs.getambassador.v3alpha1.MappingSpecLabelsSource_cluster;
+            source_cluster?: outputs.getambassador.v3alpha1.MappingSpecLabelsSourceCluster;
         }
 
         /**
          * Sets the label "destination_cluster=«Envoy destination cluster name»".
          */
-        export interface MappingSpecLabelsDestination_cluster {
+        export interface MappingSpecLabelsDestinationCluster {
             key: string;
         }
 
         /**
          * Sets the label "«key»=«value»" (where by default «key» is "generic_key").
          */
-        export interface MappingSpecLabelsGeneric_key {
+        export interface MappingSpecLabelsGenericKey {
             /**
              * The default is "generic_key".
              */
@@ -1379,14 +1379,14 @@ export namespace getambassador {
         /**
          * Sets the label "remote_address=«IP address of the client»".
          */
-        export interface MappingSpecLabelsRemote_address {
+        export interface MappingSpecLabelsRemoteAddress {
             key: string;
         }
 
         /**
          * If the «header_name» header is set, then set the label "«key»=«Value of the «header_name» header»"; otherwise skip applying this label group.
          */
-        export interface MappingSpecLabelsRequest_headers {
+        export interface MappingSpecLabelsRequestHeaders {
             header_name: string;
             key: string;
             omit_if_not_present?: boolean;
@@ -1395,18 +1395,18 @@ export namespace getambassador {
         /**
          * Sets the label "source_cluster=«Envoy source cluster name»".
          */
-        export interface MappingSpecLabelsSource_cluster {
+        export interface MappingSpecLabelsSourceCluster {
             key: string;
         }
 
-        export interface MappingSpecLoad_balancer {
-            cookie?: outputs.getambassador.v3alpha1.MappingSpecLoad_balancerCookie;
+        export interface MappingSpecLoadBalancer {
+            cookie?: outputs.getambassador.v3alpha1.MappingSpecLoadBalancerCookie;
             header?: string;
             policy: string;
             source_ip?: boolean;
         }
 
-        export interface MappingSpecLoad_balancerCookie {
+        export interface MappingSpecLoadBalancerCookie {
             name: string;
             path?: string;
             ttl?: string;
@@ -1415,17 +1415,17 @@ export namespace getambassador {
         /**
          * Prefix regex rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
          */
-        export interface MappingSpecRegex_redirect {
+        export interface MappingSpecRegexRedirect {
             pattern?: string;
             substitution?: string;
         }
 
-        export interface MappingSpecRegex_rewrite {
+        export interface MappingSpecRegexRewrite {
             pattern?: string;
             substitution?: string;
         }
 
-        export interface MappingSpecRetry_policy {
+        export interface MappingSpecRetryPolicy {
             num_retries?: number;
             per_try_timeout?: string;
             retry_on?: string;
@@ -1434,7 +1434,7 @@ export namespace getambassador {
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface MappingSpecV2explicittls {
+        export interface MappingSpecV2ExplicitTLS {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1497,13 +1497,13 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: outputs.getambassador.v3alpha1.RateLimitServiceSpecV2explicittls;
+            v2ExplicitTLS?: outputs.getambassador.v3alpha1.RateLimitServiceSpecV2ExplicitTLS;
         }
 
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface RateLimitServiceSpecV2explicittls {
+        export interface RateLimitServiceSpecV2ExplicitTLS {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1528,7 +1528,7 @@ export namespace getambassador {
              *  TODO(lukeshu): In v3alpha2, consider renaming all of the `ambassador_id` (singular) fields to `ambassador_ids` (plural).
              */
             ambassador_id?: string[];
-            circuit_breakers?: outputs.getambassador.v3alpha1.TCPMappingSpecCircuit_breakers[];
+            circuit_breakers?: outputs.getambassador.v3alpha1.TCPMappingSpecCircuitBreakers[];
             cluster_tag?: string;
             enable_ipv4?: boolean;
             enable_ipv6?: boolean;
@@ -1548,11 +1548,11 @@ export namespace getambassador {
             /**
              * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
              */
-            v2ExplicitTLS?: outputs.getambassador.v3alpha1.TCPMappingSpecV2explicittls;
+            v2ExplicitTLS?: outputs.getambassador.v3alpha1.TCPMappingSpecV2ExplicitTLS;
             weight?: number;
         }
 
-        export interface TCPMappingSpecCircuit_breakers {
+        export interface TCPMappingSpecCircuitBreakers {
             max_connections?: number;
             max_pending_requests?: number;
             max_requests?: number;
@@ -1563,7 +1563,7 @@ export namespace getambassador {
         /**
          * V2ExplicitTLS controls some vanity/stylistic elements when converting from v3alpha1 to v2.  The values in an V2ExplicitTLS should not in any way affect the runtime operation of Emissary; except that it may affect internal names in the Envoy config, which may in turn affect stats names.  But it should not affect any end-user observable behavior.
          */
-        export interface TCPMappingSpecV2explicittls {
+        export interface TCPMappingSpecV2ExplicitTLS {
             /**
              * ServiceScheme specifies how to spell and capitalize the scheme-part of the service URL. 
              *  Acceptable values are "http://" (case-insensitive), "https://" (case-insensitive), or "".  The value is used if it agrees with whether or not this resource enables TLS origination, or if something else in the resource overrides the scheme.
@@ -1616,7 +1616,7 @@ export namespace getambassador {
              */
             ambassador_id?: string[];
             config?: outputs.getambassador.v3alpha1.TracingServiceSpecConfig;
-            custom_tags?: outputs.getambassador.v3alpha1.TracingServiceSpecCustom_tags[];
+            custom_tags?: outputs.getambassador.v3alpha1.TracingServiceSpecCustomTags[];
             driver: string;
             sampling?: outputs.getambassador.v3alpha1.TracingServiceSpecSampling;
             service: string;
@@ -1642,26 +1642,26 @@ export namespace getambassador {
         /**
          * TracingCustomTag provides a data structure for capturing envoy's `type.tracing.v3.CustomTag`
          */
-        export interface TracingServiceSpecCustom_tags {
+        export interface TracingServiceSpecCustomTags {
             /**
              * Environment explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            environment?: outputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsEnvironment;
+            environment?: outputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsEnvironment;
             /**
              * Literal explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            literal?: outputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsLiteral;
+            literal?: outputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsLiteral;
             /**
              * Header explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
              */
-            request_header?: outputs.getambassador.v3alpha1.TracingServiceSpecCustom_tagsRequest_header;
+            request_header?: outputs.getambassador.v3alpha1.TracingServiceSpecCustomTagsRequestHeader;
             tag: string;
         }
 
         /**
          * Environment explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsEnvironment {
+        export interface TracingServiceSpecCustomTagsEnvironment {
             default_value?: string;
             name: string;
         }
@@ -1669,14 +1669,14 @@ export namespace getambassador {
         /**
          * Literal explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsLiteral {
+        export interface TracingServiceSpecCustomTagsLiteral {
             value: string;
         }
 
         /**
          * Header explicitly specifies the protocol stack to set up. Exactly one of Literal, Environment or Header must be supplied.
          */
-        export interface TracingServiceSpecCustom_tagsRequest_header {
+        export interface TracingServiceSpecCustomTagsRequestHeader {
             default_value?: string;
             name: string;
         }

--- a/edgey-corp/index.ts
+++ b/edgey-corp/index.ts
@@ -1,0 +1,239 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as cluster from "../cluster";
+import config from '../config'
+import * as aws from '@pulumi/aws';
+import * as ambassador from '../ambassador'
+import * as ambassadorCRDs from '../crds/ambassador'
+
+const namespace = new k8s.core.v1.Namespace('edgey-corp', {
+    metadata: {
+      name: 'edgey-corp',
+    },
+  }, { provider: cluster.provider })
+  
+export const dataprocessingService = new k8s.core.v1.Service('dataprocessing', {
+metadata: {
+    name: 'dataprocessingservice',
+    namespace: namespace.metadata.name,
+},
+spec: {
+    selector: {
+    'app.kubernetes.io/name': 'dataprocessingservice',
+    'app.kubernetes.io/part-of': 'dataprocessingservice',
+    },
+    ports: [
+    {
+        name: 'http',
+        port: 3000,
+        targetPort: 3000,
+        appProtocol: 'http'
+    },
+    ]
+}
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const dataprocessingDeployment = new k8s.apps.v1.Deployment('dataprocessing', {
+metadata: {
+    name: 'dataprocessingservice',
+    namespace: namespace.metadata.name,
+    labels: {
+    'app.kubernetes.io/name': 'dataprocessingservice',
+    'app.kubernetes.io/part-of': 'dataprocessingservice',
+    },
+},
+spec: {
+    replicas: 1,
+    selector: {
+    matchLabels: {
+        'app.kubernetes.io/name': 'dataprocessingservice',
+        'app.kubernetes.io/part-of': 'dataprocessingservice',
+    },
+    },
+    template: {
+    metadata: {
+        labels: {
+        'app.kubernetes.io/name': 'dataprocessingservice',
+        'app.kubernetes.io/part-of': 'dataprocessingservice',
+        },
+    },
+    spec: 
+    {
+        containers: [
+        {
+            name: 'dataprocessingservice',
+            image: 'docker.io/datawire/dataprocessingservice:nodejs',
+            ports: [
+            {
+                containerPort: 3000,
+                name: 'http',
+            },
+            ],
+        },
+        ],
+    },
+    },
+},
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const verylargejavaService = new k8s.core.v1.Service('verylargejava', {
+metadata: {
+    name: 'verylargejavaservice',
+    namespace: namespace.metadata.name,
+},
+spec: {
+    selector: {
+    'app.kubernetes.io/name': 'verylargejavaservice',
+    'app.kubernetes.io/part-of': 'verylargejavaservice',
+    },
+    ports: [
+    {
+        name: 'http',
+        port: 8080,
+        targetPort: 8080,
+        appProtocol: 'http'
+    },
+    ]
+}
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const verylargejavaDeployment = new k8s.apps.v1.Deployment('verylargejava', {
+metadata: {
+    name: 'verylargejavaservice',
+    namespace: namespace.metadata.name,
+    labels: {
+    'app.kubernetes.io/name': 'verylargejavaservice',
+    'app.kubernetes.io/part-of': 'verylargejavaservice',
+    },
+},
+spec: {
+    replicas: 1,
+    selector: {
+    matchLabels: {
+        'app.kubernetes.io/name': 'verylargejavaservice',
+        'app.kubernetes.io/part-of': 'verylargejavaservice',
+    },
+    },
+    template: {
+    metadata: {
+        labels: {
+        'app.kubernetes.io/name': 'verylargejavaservice',
+        'app.kubernetes.io/part-of': 'verylargejavaservice',
+        },
+    },
+    spec: 
+    {
+        containers: [
+        {
+            name: 'verylargejavaservice',
+            image: 'docker.io/datawire/verylargejavaservice',
+            ports: [
+            {
+                containerPort: 8080,
+                name: 'http',
+            },
+            ],
+        },
+        ],
+    },
+    },
+},
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const verylargedatastoreService = new k8s.core.v1.Service('verylargedatastore', {
+metadata: {
+    name: 'verylargedatastore',
+    namespace: namespace.metadata.name,
+},
+spec: {
+    selector: {
+    'app.kubernetes.io/name': 'verylargedatastore',
+    'app.kubernetes.io/part-of': 'verylargedatastore',
+    },
+    ports: [
+    {
+        name: 'http',
+        port: 8080,
+        targetPort: 8080,
+        appProtocol: 'http'
+    },
+    ]
+}
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const verylargedatastoreDeployment = new k8s.apps.v1.Deployment('verylargedatastore', {
+metadata: {
+    name: 'verylargedatastore',
+    namespace: namespace.metadata.name,
+    labels: {
+    'app.kubernetes.io/name': 'verylargedatastore',
+    'app.kubernetes.io/part-of': 'verylargedatastore',
+    },
+},
+spec: {
+    replicas: 1,
+    selector: {
+    matchLabels: {
+        'app.kubernetes.io/name': 'verylargedatastore',
+        'app.kubernetes.io/part-of': 'verylargedatastore',
+    },
+    },
+    template: {
+    metadata: {
+        labels: {
+        'app.kubernetes.io/name': 'verylargedatastore',
+        'app.kubernetes.io/part-of': 'verylargedatastore',
+        },
+    },
+    spec: 
+    {
+        containers: [
+        {
+            name: 'verylargedatastore',
+            image: 'docker.io/datawire/verylargedatastore',
+            ports: [
+            {
+                containerPort: 8080,
+                name: 'http',
+            },
+            ],
+        },
+        ],
+    },
+    },
+},
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const edgeyDomain = new aws.route53.Record('edgey', {
+zoneId: config.require('route53ZoneId'),
+name: config.require('edgeyHostPrefix'),
+type: 'A',
+records: [ambassador.publicIp],
+ttl: 300,
+allowOverwrite: true,
+}, { dependsOn: [ambassador.chart, ambassador.apiext] })
+
+export const edgeyHost = new ambassadorCRDs.getambassador.v3alpha1.Host('edgey', {
+metadata: {
+    name: 'edgey',
+    namespace: namespace.metadata.name,
+},
+spec: {
+    acmeProvider: {
+    email: config.require('email'),
+    },
+    hostname: edgeyDomain.fqdn,
+}
+}, { provider: cluster.provider, dependsOn: [edgeyDomain, ambassador.apiext] })
+
+export const verylargejavaserviceMapping = new ambassadorCRDs.getambassador.v3alpha1.Mapping('verylargejavaservice-mapping', {
+    metadata: {
+      name: 'verylargejavaservice-mapping',
+      namespace: namespace.metadata.name,
+    },
+    spec: {
+      hostname: edgeyDomain.fqdn,
+      prefix: '/',
+      service: 'verylargejavaservice.edgey-corp:8080',
+      timeout_ms: 60000
+    }
+  }, { provider: cluster.provider, dependsOn: [edgeyHost, edgeyDomain, ambassador.apiext] })

--- a/emojivoto/index.ts
+++ b/emojivoto/index.ts
@@ -454,7 +454,7 @@ export const emojiDomain = new aws.route53.Record('demo', {
   zoneId: config.require('route53ZoneId'),
   name: config.require('hostPrefix'),
   type: 'A',
-  records: [ambassador.publicIp],
+  records: [ambassador.publicURL],
   ttl: 300,
   allowOverwrite: true,
 }, { dependsOn: [ambassador.chart, ambassador.apiext] })

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,12 @@
 import * as cluster from './cluster'
 import * as ambassador from './ambassador'
+import * as ratelimiter from './ambassador/ratelimit'
+import * as waf from './ambassador/waf'
+import * as auth from './ambassador/auth'
+import * as edgey from './edgey-corp'
 import * as telepresence from './traffic-manager'
 import * as emojivoto from './emojivoto'
+import * as xss from './xss'
 
 cluster.provider
 ambassador.chart
@@ -9,8 +14,25 @@ ambassador.k8sEndpointResolver
 ambassador.httpListener
 ambassador.httpsListener
 ambassador.wildcardHost
+ratelimiter.voteRateLimiter
+waf.waf
+waf.wafPolicy
+edgey.dataprocessingDeployment
+edgey.dataprocessingService
+edgey.verylargejavaService
+edgey.verylargejavaDeployment
+edgey.verylargedatastoreDeployment
+edgey.verylargedatastoreService
+edgey.dataprocessingDeployment
+edgey.edgeyHost
+edgey.verylargejavaserviceMapping
+auth.googleFilter
+auth.googleFilterPolicy
 telepresence.chart
 emojivoto.emojiDeployment
 emojivoto.votingDeployment
 emojivoto.webDeployment
 emojivoto.voteBotDeployment
+xss.xssService
+xss.xssDeployment
+xss.xssMapping

--- a/traffic-manager/index.ts
+++ b/traffic-manager/index.ts
@@ -10,7 +10,7 @@ export const interceptCRDs = new k8s.yaml.ConfigFile('telepresence-crds', {
 export const chart = new k8s.helm.v3.Release('traffic-manager', {
   name: 'traffic-manager',
   chart: 'telepresence',
-  version: '2.14.1',
+  version: '2.16.1',
   namespace: ambassador.ambassadorNamespace.metadata.name,
   repositoryOpts: {
     repo: 'https://app.getambassador.io'

--- a/xss/index.ts
+++ b/xss/index.ts
@@ -1,0 +1,111 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as cluster from "../cluster";
+import * as aws from '@pulumi/aws';
+import config from '../config'
+import * as ambassador from '../ambassador'
+import * as ambassadorCRDs from '../crds/ambassador'
+import * as emoji from '../emojivoto'
+
+const namespace = new k8s.core.v1.Namespace('xss', {
+  metadata: {
+    name: 'xss',
+  },
+}, { provider: cluster.provider })
+
+export const xssService = new k8s.core.v1.Service('xss', {
+  metadata: {
+    name: 'xss',
+    namespace: namespace.metadata.name,
+  },
+  spec: {
+    selector: {
+      'app.kubernetes.io/name': 'xss',
+      'app.kubernetes.io/part-of': 'xss',
+    },
+    ports: [
+      {
+        name: 'http',
+        port: 5000,
+        targetPort: 5000,
+        appProtocol: 'http'
+      },
+    ]
+  }
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const xssDeployment = new k8s.apps.v1.Deployment('xss', {
+  metadata: {
+    name: 'xss',
+    namespace: namespace.metadata.name,
+    labels: {
+      'app.kubernetes.io/name': 'xss',
+      'app.kubernetes.io/part-of': 'xss',
+    },
+  },
+  spec: {
+    replicas: 1,
+    selector: {
+      matchLabels: {
+        'app.kubernetes.io/name': 'xss',
+        'app.kubernetes.io/part-of': 'xss',
+      },
+    },
+    template: {
+      metadata: {
+        labels: {
+          'app.kubernetes.io/name': 'xss',
+          'app.kubernetes.io/part-of': 'xss',
+        },
+      },
+      spec: 
+      {
+        containers: [
+          {
+            name: 'xss',
+            image: 'thedevelopnik/xss-demo:2',
+            ports: [
+              {
+                containerPort: 5000,
+                name: 'http',
+              },
+              ],
+          },
+        ],
+      },
+    },
+  },
+}, { provider: cluster.provider, dependsOn: [namespace] });
+
+export const xssDomain = new aws.route53.Record('waf', {
+  zoneId: config.require('route53ZoneId'),
+  name: config.require('xssHostPrefix'),
+  type: 'A',
+  records: [ambassador.publicIp],
+  ttl: 300,
+  allowOverwrite: true,
+}, { dependsOn: [ambassador.chart, ambassador.apiext] })
+
+export const xssHost = new ambassadorCRDs.getambassador.v3alpha1.Host('xss-host', {
+  metadata: {
+    name: 'xss-host',
+    namespace: namespace.metadata.name,
+  },
+  spec: {
+    acmeProvider: {
+      email: config.require('email'),
+    },
+    hostname: xssDomain.fqdn,
+  }
+}, { provider: cluster.provider, dependsOn: [xssDomain, ambassador.apiext] })
+
+export const xssMapping = new ambassadorCRDs.getambassador.v3alpha1.Mapping('xss-mapping', {
+  metadata: {
+    name: 'xss-mapping',
+    namespace: namespace.metadata.name,
+  },
+  spec: {
+    hostname: xssDomain.fqdn,
+    prefix: '/',
+    service: 'xss.xss:5000',
+  }
+}, { provider: cluster.provider, dependsOn: [emoji.emojiHost, emoji.emojiDomain, ambassador.apiext] })


### PR DESCRIPTION
This adds a bunch of stuff for further demos for Edge Stack:

* an XSS (cross-site scripting) vulnerable app that is protected by the WAF
* the Edgey-Corp app that is protected by Google SSO OAuth
* Rate limiting on Emojivoto so that a given user can only vote 3 times per minute

They are all at different subdomains to show off that capability. Edgey corp could also be used to do TP demos in the same way as the TP quickstart. Next I want to add easy capability for personal intercepts using custom http headers.

This is WIP. Need to clean it up and add documentation, so putting it in draft mode.

